### PR TITLE
docs: fix contributor names in RN + Re.Pack docs

### DIFF
--- a/docs/recipes/repack-mf.mdx
+++ b/docs/recipes/repack-mf.mdx
@@ -78,10 +78,10 @@ Huge thanks for [Callstack](https://callstack.com) for working with us to make t
 
 [Jakub Romańczyk](https://github.com/jbroma)
 
-[Maciej Budzinski](https://github.com/maciekBudzinski)
+[Maciej Budziński](https://github.com/maciekBudzinski)
 
 [Kacper Wiszczuk](https://github.com/Esemesek)
 
 [Boris Yankov](https://github.com/borisyankov)
 
-[Maciej Lodygowsk](https://github.com/draggie)
+[Maciej Łodygowski](https://github.com/draggie)


### PR DESCRIPTION
### What's added in this PR?

- [x] - fixed contributor names in the docs for RN + Re.Pack + Zephyr guide