### PR TITLE
fix "Adding Zephyr to existing application" link

### DIFF
--- a/lib/site.config.tsx
+++ b/lib/site.config.tsx
@@ -53,7 +53,7 @@ export const SiteConfig: CardProps = {
       title: "Adding Zephyr to existing application",
       description:
         "One line of code to add Zephyr to your existing application. Use Nx + React + Webpack as an example.",
-      href: "/how-to/existing-app",
+      href: "/recipes/existing-app",
       variant: "small",
     },
     // {


### PR DESCRIPTION
<img width="307" height="219" alt="image" src="https://github.com/user-attachments/assets/62ad6459-7809-4144-83c3-1d4230b325f1" />
<img width="724" height="389" alt="image" src="https://github.com/user-attachments/assets/870a340b-c7b9-409b-abb9-4cffd666bf6c" />

on https://docs.zephyr-cloud.io/ the link points to https://docs.zephyr-cloud.io/how-to/existing-app (404) instead of https://docs.zephyr-cloud.io/recipes/existing-app (200)