### PR TITLE
build(pnpm): force patched versions for protobufjs and handlebars

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,10 @@
     "zephyr-rspress-plugin": "^0.1.10"
   },
   "pnpm": {
+    "overrides": {
+      "protobufjs": ">=7.5.5 <8",
+      "handlebars": ">=4.7.9"
+    },
     "patchedDependencies": {
       "rsbuild-plugin-google-analytics@1.0.4": "patches/rsbuild-plugin-google-analytics@1.0.4.patch"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  protobufjs: '>=7.5.5 <8'
+  handlebars: '>=4.7.9'
+
 patchedDependencies:
   rsbuild-plugin-google-analytics@1.0.4:
     hash: 6002602d312e1a83bfd588644f8cd9f9b0d2085841d2809a45e424b4d8e2fdd4
@@ -3111,8 +3115,8 @@ packages:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -4530,8 +4534,8 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   protocols@2.0.2:
@@ -6481,7 +6485,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
   '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -8186,7 +8190,7 @@ snapshots:
   conventional-changelog-writer@8.2.0:
     dependencies:
       conventional-commits-filter: 5.0.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       meow: 13.2.0
       semver: 7.7.1
 
@@ -9012,7 +9016,7 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2
@@ -10920,7 +10924,7 @@ snapshots:
 
   proto-list@1.2.4: {}
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
<!-- Created by open-pr command -->

### What's added in this PR?

Adds `pnpm.overrides` to force minimum safe versions for two critical transitive dependencies:

- `protobufjs` bumped `7.5.4 → 7.5.5` (stays within `^7.3.0` range required by `@opentelemetry/otlp-transformer`)
- `handlebars` bumped `4.7.8 → 4.7.9`

### What's the issues or discussion related to this PR (optional)?

Fixes two critical Dependabot security alerts:
- [#115](https://github.com/ZephyrCloudIO/zephyr-documentation/security/dependabot/115) — `protobufjs`: Arbitrary code execution
- [#95](https://github.com/ZephyrCloudIO/zephyr-documentation/security/dependabot/95) — `handlebars`: JavaScript injection via AST type confusion

Both are transitive deps pulled in by `posthog-js` → `@opentelemetry` (protobufjs) and `semantic-release` → `conventional-changelog-writer` (handlebars).

### Feature related update for this PR (if applicable)?

N/A — security patch only, no behaviour change.

### (Optional) What's left to be done for this PR?

### Who do you wish to review this PR other than required reviewers?

<!-- @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [x] I have added/updated our feature to sync with this PR
- [x] I have added an explanation of my changes
- [x] I have/will run tests, or ask for help to add test