### PR TITLE
feat: replace GTM for posthog

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "lucide-react": "^0.544.0",
     "posthog-js": "^1.272.0",
     "react-wrap-balancer": "^1.1.1",
-    "rsbuild-plugin-google-analytics": "^1.0.4",
     "rspress-plugin-file-tree": "^0.4.0",
     "rspress-plugin-mermaid": "^1.0.0",
     "rspress-plugin-reading-time": "^1.0.0",
@@ -86,9 +85,7 @@
       "protobufjs": ">=7.5.5 <8",
       "handlebars": ">=4.7.9"
     },
-    "patchedDependencies": {
-      "rsbuild-plugin-google-analytics@1.0.4": "patches/rsbuild-plugin-google-analytics@1.0.4.patch"
-    }
+    "patchedDependencies": {}
   },
   "packageManager": "pnpm@10.33.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,11 +8,6 @@ overrides:
   protobufjs: '>=7.5.5 <8'
   handlebars: '>=4.7.9'
 
-patchedDependencies:
-  rsbuild-plugin-google-analytics@1.0.4:
-    hash: 6002602d312e1a83bfd588644f8cd9f9b0d2085841d2809a45e424b4d8e2fdd4
-    path: patches/rsbuild-plugin-google-analytics@1.0.4.patch
-
 importers:
 
   .:
@@ -74,9 +69,6 @@ importers:
       react-wrap-balancer:
         specifier: ^1.1.1
         version: 1.1.1(react@19.2.4)
-      rsbuild-plugin-google-analytics:
-        specifier: ^1.0.4
-        version: 1.0.4(patch_hash=6002602d312e1a83bfd588644f8cd9f9b0d2085841d2809a45e424b4d8e2fdd4)(@rsbuild/core@2.0.0-beta.0(core-js@3.45.1))
       rspress-plugin-file-tree:
         specifier: ^0.4.0
         version: 0.4.0(rspress@1.45.6(webpack@5.96.0))
@@ -4800,14 +4792,6 @@ packages:
 
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
-
-  rsbuild-plugin-google-analytics@1.0.4:
-    resolution: {integrity: sha512-K7KkgIUJWtoBpcCLBDLnBXezvQWdue5LCDO4NDvSDe/TEFxOlKb8wG6dDtp/A+CwbnZRVeNOZ9cB6vNg/y/Suw==}
-    peerDependencies:
-      '@rsbuild/core': 1.x
-    peerDependenciesMeta:
-      '@rsbuild/core':
-        optional: true
 
   rsbuild-plugin-open-graph@1.1.0:
     resolution: {integrity: sha512-ETrmQxhs/hW7xFzDGb6CIiZ1tVOrsrGPDgPTC/49bQ+sK75y6LZ3/CvcqPNxMwdnI3Ba79l62FIFvR0uC+UISw==}
@@ -11334,10 +11318,6 @@ snapshots:
   rfdc@1.4.1: {}
 
   robust-predicates@3.0.2: {}
-
-  rsbuild-plugin-google-analytics@1.0.4(patch_hash=6002602d312e1a83bfd588644f8cd9f9b0d2085841d2809a45e424b4d8e2fdd4)(@rsbuild/core@2.0.0-beta.0(core-js@3.45.1)):
-    optionalDependencies:
-      '@rsbuild/core': 2.0.0-beta.0(core-js@3.45.1)
 
   rsbuild-plugin-open-graph@1.1.0(@rsbuild/core@2.0.0-beta.0(core-js@3.45.1)):
     optionalDependencies:

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -2,7 +2,7 @@ import * as path from 'node:path';
 import { pluginClientRedirects } from '@rspress/plugin-client-redirects';
 import type { Nav, Sidebar, SocialLink } from '@rspress/shared';
 import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
-import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
+
 import { pluginLlms } from '@rspress/plugin-llms';
 import { pluginAlgolia } from '@rspress/plugin-algolia';
 import pluginMermaid from 'rspress-plugin-mermaid';
@@ -431,9 +431,6 @@ export default defineConfig({
           site: '@ZephyrCloudIO',
           card: 'summary_large_image',
         },
-      }),
-      pluginGoogleAnalytics({
-        id: 'G-B7G266JZDH',
       }),
     ],
     output: {


### PR DESCRIPTION
<!-- Created by open-pr command -->

## 🎫 Ticket

- https://app.clickup.com/t/9013031642/ZE-1374

## 🧠 Why

Google Tag Manager and GA4 were running parallel to PostHog analytics. Removing GTM eliminates duplicated analytics data, reduces maintenance overhead, and centralizes all product analytics through PostHog for consistency across Zephyr properties.

## 📝 What changed

- Removed `rsbuild-plugin-google-analytics` import and usage from `rspress.config.ts`
- Deleted `rsbuild-plugin-google-analytics` dependency from `package.json`
- Removed patch file `patches/rsbuild-plugin-google-analytics@1.0.4.patch`
- Cleaned up `patchedDependencies` section in `package.json`
- PostHog analytics remain fully configured in `theme/index.tsx` with proper initialization

## 🧪 How to test

| Step                                 | Expected result                                       |
| ------------------------------------ | ----------------------------------------------------- |
| Start docs locally (`pnpm dev`)      | No GTM/GA4 network requests in DevTools               |
| Navigate between documentation pages | PostHog captures analytics events properly            |
| Run build (`pnpm build`)             | Build succeeds without Google Analytics plugin errors |
| Check PostHog Live Events            | Events arrive with correct page context               |

## 📸 Screenshots

N/A — analytics change with no visible UI difference. PostHog continues tracking all user interactions.
