### PR TITLE
docs(errors): document ZE20014 (failed to load application configuration)

### DIFF
--- a/docs/errors/ze20014.mdx
+++ b/docs/errors/ze20014.mdx
@@ -1,14 +1,15 @@
 ---
-title: 'ZE20014: Error not yet documented'
-description: 'ZE20014: Error code not yet documented'
+title: 'ZE20014: Failed to load application configuration'
+description: 'ZE20014: Zephyr could not load the application configuration during deployment'
 head:
   - - meta
     - property: og:description
-      content: 'ZE20014: Error code not yet documented'
+      content: 'ZE20014: Zephyr could not load the application configuration during deployment'
 ---
 
 import { getErrorMessage } from '../../lib/error-helpers.ts';
 import { ErrorInfo } from '../../components/errors/info.tsx';
+import { Steps } from '@rspress/core/theme';
 
 # {getErrorMessage('ZE20014')}
 
@@ -18,6 +19,40 @@ The fastest way to resolve this error is to [join our Discord](https://discord.g
 
 <ErrorInfo code="ZE20014" terminal />
 
+This error happens during deployment when the Zephyr plugin requests your application configuration from the Zephyr API (using your `application_uid`), but the request fails or returns no configuration. It is most often caused by a stale local cache in `~/.zephyr`, an expired authentication token, or a temporary network/API issue.
+
+<Steps>
+
+### Clear the local Zephyr cache
+
+A stale or corrupted cached configuration is the most common cause. Remove the cache folder and re-run your deployment:
+
+rm -rf ~/.zephyr
+
+### Re-authenticate with Zephyr
+
+The configuration request is authenticated with your token. If it has expired, sign in again before retrying.
+
+npx ze login
+
+### Ensure you are running the latest Zephyr plugin
+
+Update your Zephyr plugin to the latest version to ensure you have the latest fixes.
+
+# Choose the plugin you are using
+
+npm install zephyr-webpack-plugin --latest
+npm install rollup-plugin-zephyr --latest
+npm install vite-plugin-zephyr --latest
+
+### Retry your deployment
+
+This error can be transient. After clearing the cache and re-authenticating, run your build again.
+
+npm run build
+
+</Steps>
+
 ::: warning
-This error is not yet documented. Please contact us on Discord for assistance.
+If the error persists after clearing `~/.zephyr` and re-authenticating, your `application_uid` may not be resolvable or the API may be temporarily unavailable. Please [contact us on Discord](https://discord.gg/zephyrcloud) with your deployment logs so we can help.
 :::

--- a/docs/errors/ze20014.mdx
+++ b/docs/errors/ze20014.mdx
@@ -29,11 +29,9 @@ A stale or corrupted cached configuration is the most common cause. Remove the c
 
 rm -rf ~/.zephyr
 
-### Re-authenticate with Zephyr
+### Sign in again on your next build
 
-The configuration request is authenticated with your token. If it has expired, sign in again before retrying.
-
-npx ze login
+Clearing the cache also removes your stored credentials. The next time you build, Zephyr will open a browser window and prompt you to sign in again, refreshing the token used to load your application configuration.
 
 ### Ensure you are running the latest Zephyr plugin
 
@@ -41,9 +39,9 @@ Update your Zephyr plugin to the latest version to ensure you have the latest fi
 
 # Choose the plugin you are using
 
-npm install zephyr-webpack-plugin --latest
-npm install rollup-plugin-zephyr --latest
-npm install vite-plugin-zephyr --latest
+npm install zephyr-webpack-plugin@latest
+npm install rollup-plugin-zephyr@latest
+npm install vite-plugin-zephyr@latest
 
 ### Retry your deployment
 


### PR DESCRIPTION
### What's added in this PR?

Replaces the placeholder content for `ZE20014` (`docs/errors/ze20014.mdx`) with real documentation: a description of the cause (the plugin fails to load the application configuration from the Zephyr API during deploy — `ERR_LOAD_APP_CONFIG`) plus a `<Steps>` resolution flow (clear the `~/.zephyr` cache, re-authenticate, update the plugin, retry). Structure mirrors the other documented error pages (e.g. `ze20013`).

### What's the issues or discussion related to this PR (optional) ?

ZE-239 (https://app.clickup.com/t/86adx85y9) — subtask of filling missing/placeholder error docs based on plugin returns. Previously the page only showed the "not yet documented" placeholder.

### Feature related update for this PR (if applicable)?

N/A

### (Optional) What's left to be done for this PR?

The resolution steps were inferred from the agent source (`ERR_LOAD_APP_CONFIG` in `zephyr-agent`). If there is exact customer-facing guidance for ZE20014, the wording can be refined.

### Who do you wish to review this PR other than required reviewers?

### (Required) Pre-PR/Merge checklist

- [x] I have added/updated our feature to sync with this PR
- [x] I have added an explanation of my changes
- [ ] I have/will run tests, or ask for help to add test

Made with [Cursor](https://cursor.com)