### PR TITLE
docs(kubernetes): document worker observability

### DIFF
--- a/docs/cloud/kubernetes.mdx
+++ b/docs/cloud/kubernetes.mdx
@@ -37,7 +37,7 @@ Alternatively, you can use environment variables directly, though this is less r
 
 ### JSON Config File (Recommended)
 
-Create a JSON file containing all your configuration. All keys use the `ZE_WORKER_` prefix:
+Create a JSON file containing all your configuration. Worker-specific keys use the `ZE_WORKER_` prefix; OpenTelemetry keys use the standard `OTEL_` prefix:
 
 ```jsonc
 // Example configuration
@@ -46,12 +46,11 @@ Create a JSON file containing all your configuration. All keys use the `ZE_WORKE
   "ZE_WORKER_JWT_SECRET": "your-secret-key",
   "ZE_WORKER_LOG_LEVEL": "info",
   "ZE_WORKER_DELIMITER": "-",
-  "ZE_WORKER_OTEL_ENABLED": "true",
-  "ZE_WORKER_OTEL_SERVICE_NAME": "ze-k8s-workers",
-  "ZE_WORKER_OTEL_DEPLOYMENT_ENVIRONMENT": "production",
-  "ZE_WORKER_OTEL_METRIC_EXPORT_INTERVAL_MS": "60000",
-  "ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel-collector.observability.svc.cluster.local:4318/v1",
-  "ZE_WORKER_OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer%20your-token",
+  "OTEL_SERVICE_NAME": "ze-k8s-workers",
+  "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment.name=production",
+  "OTEL_METRIC_EXPORT_INTERVAL": "60000",
+  "OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel-collector.observability.svc.cluster.local:4318",
+  "OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer%20your-token",
   "ZE_WORKER_S3_ENDPOINT": "https://s3.amazonaws.com",
   "ZE_WORKER_S3_REGION": "us-east-1",
   "ZE_WORKER_S3_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
@@ -89,23 +88,21 @@ The worker exposes the following health check endpoints for Kubernetes probes:
 
 ## Observability
 
-The Kubernetes worker emits OpenTelemetry traces, metrics, and logs over OTLP HTTP. Enable telemetry with `ZE_WORKER_OTEL_ENABLED=true`, any `ZE_WORKER_OTEL_EXPORTER_OTLP_*` endpoint, or standard `OTEL_EXPORTER_OTLP_*` environment variables.
+The Kubernetes worker emits OpenTelemetry traces, metrics, and logs over OTLP HTTP. Enable telemetry with any `OTEL_EXPORTER_OTLP_*` endpoint or by explicitly setting a signal exporter such as `OTEL_TRACES_EXPORTER=otlp`.
 
-If you set only `ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT`, the worker treats it as the versioned OTLP HTTP endpoint and sends each signal to:
+If you set only `OTEL_EXPORTER_OTLP_ENDPOINT`, the worker treats it as the collector base URL and sends each signal to:
 
-- Traces: `<endpoint>/traces`
-- Metrics: `<endpoint>/metrics`
-- Logs: `<endpoint>/logs`
-
-Unversioned collector base URLs are also accepted for compatibility. For example, `http://otel-collector:4318` resolves to `/v1/traces`, `/v1/metrics`, and `/v1/logs`.
+- Traces: `<endpoint>/v1/traces`
+- Metrics: `<endpoint>/v1/metrics`
+- Logs: `<endpoint>/v1/logs`
 
 Use the signal-specific endpoint variables when your collector exposes separate routes:
 
 ```jsonc
 {
-  "ZE_WORKER_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://otel-collector:4318/v1/traces",
-  "ZE_WORKER_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://otel-collector:4318/v1/metrics",
-  "ZE_WORKER_OTEL_EXPORTER_OTLP_LOGS_ENDPOINT": "http://otel-collector:4318/v1/logs",
+  "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://otel-collector:4318/v1/traces",
+  "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://otel-collector:4318/v1/metrics",
+  "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT": "http://otel-collector:4318/v1/logs",
 }
 ```
 
@@ -115,8 +112,8 @@ For collectors that require authentication, set OTLP headers using comma-separat
 
 ```jsonc
 {
-  "ZE_WORKER_OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer%20your-token",
-  "ZE_WORKER_OTEL_EXPORTER_OTLP_TRACES_HEADERS": "x-api-key=trace-key",
+  "OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer%20your-token",
+  "OTEL_EXPORTER_OTLP_TRACES_HEADERS": "x-api-key=trace-key",
 }
 ```
 
@@ -175,22 +172,23 @@ Below is the complete reference for all available configuration options. These c
 
 ### OpenTelemetry Options
 
-| Key                                             | Description                                  | Default                            | Example                                 |
-| ----------------------------------------------- | -------------------------------------------- | ---------------------------------- | --------------------------------------- |
-| `ZE_WORKER_OTEL_ENABLED`                        | Enables OpenTelemetry export                 | `false`                            | `true`                                  |
-| `ZE_WORKER_OTEL_SERVICE_NAME`                   | Service name resource attribute              | `ze-k8s-workers`                   | `ze-k8s-workers-prod`                   |
-| `ZE_WORKER_OTEL_DEPLOYMENT_ENVIRONMENT`         | Deployment environment resource attribute    | `NODE_ENV`, otherwise `production` | `production`                            |
-| `ZE_WORKER_OTEL_METRIC_EXPORT_INTERVAL_MS`      | OTLP metric export interval in milliseconds  | `60000`                            | `30000`                                 |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT`         | Versioned OTLP HTTP endpoint for all signals | _(unset)_                          | `http://otel-collector:4318/v1`         |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | Signal-specific OTLP HTTP traces endpoint    | _(unset)_                          | `http://otel-collector:4318/v1/traces`  |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Signal-specific OTLP HTTP metrics endpoint   | _(unset)_                          | `http://otel-collector:4318/v1/metrics` |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`    | Signal-specific OTLP HTTP logs endpoint      | _(unset)_                          | `http://otel-collector:4318/v1/logs`    |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_HEADERS`          | Base OTLP HTTP headers for all signals       | _(unset)_                          | `Authorization=Bearer%20TOKEN`          |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_TRACES_HEADERS`   | Signal-specific OTLP HTTP traces headers     | _(unset)_                          | `x-api-key=trace-key`                   |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_METRICS_HEADERS`  | Signal-specific OTLP HTTP metrics headers    | _(unset)_                          | `x-api-key=metrics-key`                 |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_LOGS_HEADERS`     | Signal-specific OTLP HTTP logs headers       | _(unset)_                          | `x-api-key=logs-key`                    |
-
-The worker also honors standard `OTEL_EXPORTER_OTLP_*` environment variables, including `OTEL_EXPORTER_OTLP_HEADERS` and signal-specific header variables. Standard `OTEL_EXPORTER_OTLP_ENDPOINT` keeps the OpenTelemetry base endpoint behavior and appends `/v1/{signal}`. Signal-specific endpoint and header variables take precedence over the base values. `OTEL_SDK_DISABLED=true` disables telemetry.
+| Key                                   | Description                                 | Default                                                               | Example                                  |
+| ------------------------------------- | ------------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------- |
+| `OTEL_SDK_DISABLED`                   | Disables OpenTelemetry export               | _(unset)_                                                             | `true`                                   |
+| `OTEL_SERVICE_NAME`                   | Service name resource attribute             | `ze-k8s-workers`                                                      | `ze-k8s-workers-prod`                    |
+| `OTEL_RESOURCE_ATTRIBUTES`            | Additional resource attributes              | `deployment.environment.name` from `NODE_ENV`, otherwise `production` | `deployment.environment.name=production` |
+| `OTEL_METRIC_EXPORT_INTERVAL`         | OTLP metric export interval in milliseconds | `60000`                                                               | `30000`                                  |
+| `OTEL_TRACES_EXPORTER`                | Trace exporter selection                    | _(unset)_                                                             | `otlp` or `none`                         |
+| `OTEL_METRICS_EXPORTER`               | Metrics exporter selection                  | _(unset)_                                                             | `otlp` or `none`                         |
+| `OTEL_LOGS_EXPORTER`                  | Logs exporter selection                     | _(unset)_                                                             | `otlp` or `none`                         |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`         | Base OTLP HTTP endpoint for all signals     | _(unset)_                                                             | `http://otel-collector:4318`             |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | Signal-specific OTLP HTTP traces endpoint   | _(unset)_                                                             | `http://otel-collector:4318/v1/traces`   |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Signal-specific OTLP HTTP metrics endpoint  | _(unset)_                                                             | `http://otel-collector:4318/v1/metrics`  |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`    | Signal-specific OTLP HTTP logs endpoint     | _(unset)_                                                             | `http://otel-collector:4318/v1/logs`     |
+| `OTEL_EXPORTER_OTLP_HEADERS`          | Base OTLP HTTP headers for all signals      | _(unset)_                                                             | `Authorization=Bearer%20TOKEN`           |
+| `OTEL_EXPORTER_OTLP_TRACES_HEADERS`   | Signal-specific OTLP HTTP traces headers    | _(unset)_                                                             | `x-api-key=trace-key`                    |
+| `OTEL_EXPORTER_OTLP_METRICS_HEADERS`  | Signal-specific OTLP HTTP metrics headers   | _(unset)_                                                             | `x-api-key=metrics-key`                  |
+| `OTEL_EXPORTER_OTLP_LOGS_HEADERS`     | Signal-specific OTLP HTTP logs headers      | _(unset)_                                                             | `x-api-key=logs-key`                     |
 
 ### S3 Options
 
@@ -459,7 +457,7 @@ All workers have `ZE_WORKER_REPLICAS_URLS` pointing to other regions' load balan
 
 1. Confirm the collector accepts OTLP HTTP, not only OTLP gRPC
 2. Verify the worker pod can resolve and connect to the collector service
-3. Use the versioned OTLP HTTP endpoint for `ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT`, for example `http://otel-collector:4318/v1`
+3. Use the collector base URL for `OTEL_EXPORTER_OTLP_ENDPOINT`, for example `http://otel-collector:4318`
 4. Include the full `/v1/traces`, `/v1/metrics`, or `/v1/logs` path when using signal-specific endpoints
 5. Configure OTLP headers when the collector requires a bearer token, API key, or tenant header
 6. Confirm `OTEL_SDK_DISABLED` is not set to `true`

--- a/docs/cloud/kubernetes.mdx
+++ b/docs/cloud/kubernetes.mdx
@@ -50,7 +50,7 @@ Create a JSON file containing all your configuration. All keys use the `ZE_WORKE
   "ZE_WORKER_OTEL_SERVICE_NAME": "ze-k8s-workers",
   "ZE_WORKER_OTEL_DEPLOYMENT_ENVIRONMENT": "production",
   "ZE_WORKER_OTEL_METRIC_EXPORT_INTERVAL_MS": "60000",
-  "ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel-collector.observability.svc.cluster.local:4318",
+  "ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel-collector.observability.svc.cluster.local:4318/v1",
   "ZE_WORKER_OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer%20your-token",
   "ZE_WORKER_S3_ENDPOINT": "https://s3.amazonaws.com",
   "ZE_WORKER_S3_REGION": "us-east-1",
@@ -91,11 +91,13 @@ The worker exposes the following health check endpoints for Kubernetes probes:
 
 The Kubernetes worker emits OpenTelemetry traces, metrics, and logs over OTLP HTTP. Enable telemetry with `ZE_WORKER_OTEL_ENABLED=true`, any `ZE_WORKER_OTEL_EXPORTER_OTLP_*` endpoint, or standard `OTEL_EXPORTER_OTLP_*` environment variables.
 
-If you set only `ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT`, the worker treats it as the collector base URL and sends each signal to:
+If you set only `ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT`, the worker treats it as the versioned OTLP HTTP endpoint and sends each signal to:
 
-- Traces: `<base>/v1/traces`
-- Metrics: `<base>/v1/metrics`
-- Logs: `<base>/v1/logs`
+- Traces: `<endpoint>/traces`
+- Metrics: `<endpoint>/metrics`
+- Logs: `<endpoint>/logs`
+
+Unversioned collector base URLs are also accepted for compatibility. For example, `http://otel-collector:4318` resolves to `/v1/traces`, `/v1/metrics`, and `/v1/logs`.
 
 Use the signal-specific endpoint variables when your collector exposes separate routes:
 
@@ -173,22 +175,22 @@ Below is the complete reference for all available configuration options. These c
 
 ### OpenTelemetry Options
 
-| Key                                             | Description                                 | Default                            | Example                                 |
-| ----------------------------------------------- | ------------------------------------------- | ---------------------------------- | --------------------------------------- |
-| `ZE_WORKER_OTEL_ENABLED`                        | Enables OpenTelemetry export                | `false`                            | `true`                                  |
-| `ZE_WORKER_OTEL_SERVICE_NAME`                   | Service name resource attribute             | `ze-k8s-workers`                   | `ze-k8s-workers-prod`                   |
-| `ZE_WORKER_OTEL_DEPLOYMENT_ENVIRONMENT`         | Deployment environment resource attribute   | `NODE_ENV`, otherwise `production` | `production`                            |
-| `ZE_WORKER_OTEL_METRIC_EXPORT_INTERVAL_MS`      | OTLP metric export interval in milliseconds | `60000`                            | `30000`                                 |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT`         | Base OTLP HTTP endpoint for all signals     | _(unset)_                          | `http://otel-collector:4318`            |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | Signal-specific OTLP HTTP traces endpoint   | _(unset)_                          | `http://otel-collector:4318/v1/traces`  |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Signal-specific OTLP HTTP metrics endpoint  | _(unset)_                          | `http://otel-collector:4318/v1/metrics` |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`    | Signal-specific OTLP HTTP logs endpoint     | _(unset)_                          | `http://otel-collector:4318/v1/logs`    |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_HEADERS`          | Base OTLP HTTP headers for all signals      | _(unset)_                          | `Authorization=Bearer%20TOKEN`          |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_TRACES_HEADERS`   | Signal-specific OTLP HTTP traces headers    | _(unset)_                          | `x-api-key=trace-key`                   |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_METRICS_HEADERS`  | Signal-specific OTLP HTTP metrics headers   | _(unset)_                          | `x-api-key=metrics-key`                 |
-| `ZE_WORKER_OTEL_EXPORTER_OTLP_LOGS_HEADERS`     | Signal-specific OTLP HTTP logs headers      | _(unset)_                          | `x-api-key=logs-key`                    |
+| Key                                             | Description                                  | Default                            | Example                                 |
+| ----------------------------------------------- | -------------------------------------------- | ---------------------------------- | --------------------------------------- |
+| `ZE_WORKER_OTEL_ENABLED`                        | Enables OpenTelemetry export                 | `false`                            | `true`                                  |
+| `ZE_WORKER_OTEL_SERVICE_NAME`                   | Service name resource attribute              | `ze-k8s-workers`                   | `ze-k8s-workers-prod`                   |
+| `ZE_WORKER_OTEL_DEPLOYMENT_ENVIRONMENT`         | Deployment environment resource attribute    | `NODE_ENV`, otherwise `production` | `production`                            |
+| `ZE_WORKER_OTEL_METRIC_EXPORT_INTERVAL_MS`      | OTLP metric export interval in milliseconds  | `60000`                            | `30000`                                 |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT`         | Versioned OTLP HTTP endpoint for all signals | _(unset)_                          | `http://otel-collector:4318/v1`         |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | Signal-specific OTLP HTTP traces endpoint    | _(unset)_                          | `http://otel-collector:4318/v1/traces`  |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Signal-specific OTLP HTTP metrics endpoint   | _(unset)_                          | `http://otel-collector:4318/v1/metrics` |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`    | Signal-specific OTLP HTTP logs endpoint      | _(unset)_                          | `http://otel-collector:4318/v1/logs`    |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_HEADERS`          | Base OTLP HTTP headers for all signals       | _(unset)_                          | `Authorization=Bearer%20TOKEN`          |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_TRACES_HEADERS`   | Signal-specific OTLP HTTP traces headers     | _(unset)_                          | `x-api-key=trace-key`                   |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_METRICS_HEADERS`  | Signal-specific OTLP HTTP metrics headers    | _(unset)_                          | `x-api-key=metrics-key`                 |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_LOGS_HEADERS`     | Signal-specific OTLP HTTP logs headers       | _(unset)_                          | `x-api-key=logs-key`                    |
 
-The worker also honors standard `OTEL_EXPORTER_OTLP_*` environment variables, including `OTEL_EXPORTER_OTLP_HEADERS` and signal-specific header variables. Signal-specific endpoint and header variables take precedence over the base values. `OTEL_SDK_DISABLED=true` disables telemetry.
+The worker also honors standard `OTEL_EXPORTER_OTLP_*` environment variables, including `OTEL_EXPORTER_OTLP_HEADERS` and signal-specific header variables. Standard `OTEL_EXPORTER_OTLP_ENDPOINT` keeps the OpenTelemetry base endpoint behavior and appends `/v1/{signal}`. Signal-specific endpoint and header variables take precedence over the base values. `OTEL_SDK_DISABLED=true` disables telemetry.
 
 ### S3 Options
 
@@ -457,7 +459,7 @@ All workers have `ZE_WORKER_REPLICAS_URLS` pointing to other regions' load balan
 
 1. Confirm the collector accepts OTLP HTTP, not only OTLP gRPC
 2. Verify the worker pod can resolve and connect to the collector service
-3. Use the collector base URL for `ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT`, for example `http://otel-collector:4318`
+3. Use the versioned OTLP HTTP endpoint for `ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT`, for example `http://otel-collector:4318/v1`
 4. Include the full `/v1/traces`, `/v1/metrics`, or `/v1/logs` path when using signal-specific endpoints
 5. Configure OTLP headers when the collector requires a bearer token, API key, or tenant header
 6. Confirm `OTEL_SDK_DISABLED` is not set to `true`

--- a/docs/cloud/kubernetes.mdx
+++ b/docs/cloud/kubernetes.mdx
@@ -27,6 +27,7 @@ The Kubernetes edge worker is a containerized service that handles asset uploads
 
 - **S3-compatible storage** (AWS S3, MinIO, Ceph, etc.) for asset storage
 - **Redis-compatible KV store** for environment configuration and snapshots
+- **OpenTelemetry-compatible collectors** for OTLP HTTP traces, metrics, and logs
 
 ## Configuration
 
@@ -45,6 +46,12 @@ Create a JSON file containing all your configuration. All keys use the `ZE_WORKE
   "ZE_WORKER_JWT_SECRET": "your-secret-key",
   "ZE_WORKER_LOG_LEVEL": "info",
   "ZE_WORKER_DELIMITER": "-",
+  "ZE_WORKER_OTEL_ENABLED": "true",
+  "ZE_WORKER_OTEL_SERVICE_NAME": "ze-k8s-workers",
+  "ZE_WORKER_OTEL_DEPLOYMENT_ENVIRONMENT": "production",
+  "ZE_WORKER_OTEL_METRIC_EXPORT_INTERVAL_MS": "60000",
+  "ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel-collector.observability.svc.cluster.local:4318",
+  "ZE_WORKER_OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer%20your-token",
   "ZE_WORKER_S3_ENDPOINT": "https://s3.amazonaws.com",
   "ZE_WORKER_S3_REGION": "us-east-1",
   "ZE_WORKER_S3_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
@@ -80,6 +87,61 @@ The worker exposes the following health check endpoints for Kubernetes probes:
 | `GET /healthz` | Liveness probe  | Always returns `200` if the process is running                           |
 | `GET /readyz`  | Readiness probe | Checks S3 and Redis connectivity; returns `200` if healthy, `503` if not |
 
+## Observability
+
+The Kubernetes worker emits OpenTelemetry traces, metrics, and logs over OTLP HTTP. Enable telemetry with `ZE_WORKER_OTEL_ENABLED=true`, any `ZE_WORKER_OTEL_EXPORTER_OTLP_*` endpoint, or standard `OTEL_EXPORTER_OTLP_*` environment variables.
+
+If you set only `ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT`, the worker treats it as the collector base URL and sends each signal to:
+
+- Traces: `<base>/v1/traces`
+- Metrics: `<base>/v1/metrics`
+- Logs: `<base>/v1/logs`
+
+Use the signal-specific endpoint variables when your collector exposes separate routes:
+
+```jsonc
+{
+  "ZE_WORKER_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://otel-collector:4318/v1/traces",
+  "ZE_WORKER_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://otel-collector:4318/v1/metrics",
+  "ZE_WORKER_OTEL_EXPORTER_OTLP_LOGS_ENDPOINT": "http://otel-collector:4318/v1/logs",
+}
+```
+
+Signal-specific endpoint variables export only their configured signal unless a shared base endpoint is also set.
+
+For collectors that require authentication, set OTLP headers using comma-separated `key=value` pairs. Percent-encode spaces and other special characters:
+
+```jsonc
+{
+  "ZE_WORKER_OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer%20your-token",
+  "ZE_WORKER_OTEL_EXPORTER_OTLP_TRACES_HEADERS": "x-api-key=trace-key",
+}
+```
+
+Store header values that contain tokens, API keys, or tenant credentials in a Kubernetes Secret.
+
+Set `OTEL_SDK_DISABLED=true` to force telemetry off, even when endpoints are configured.
+
+| Signal  | Coverage                                                                |
+| ------- | ----------------------------------------------------------------------- |
+| Traces  | HTTP requests, readiness checks, Redis operations, and S3 operations    |
+| Metrics | HTTP request counts/duration, storage operation counts/duration, checks |
+| Logs    | Structured worker logs with trace and span IDs when a span is active    |
+
+Worker stdout is structured JSON:
+
+```json
+{
+  "timestamp": "2026-06-29T04:31:14.288Z",
+  "level": "info",
+  "service": "ze-k8s-workers",
+  "replica": "primary",
+  "message": "Worker listening",
+  "server.port": 8080,
+  "otel.enabled": true
+}
+```
+
 ## Configuration Reference
 
 Below is the complete reference for all available configuration options. These can be set in your JSON config file or as environment variables.
@@ -108,6 +170,25 @@ Below is the complete reference for all available configuration options. These c
 | `ZE_WORKER_PORT`      | HTTP server port               | `8080`  | `3000`                                     |
 | `ZE_WORKER_LOG_LEVEL` | Logging level                  | `info`  | `debug`, `trace`, `warn`, `error`, `fatal` |
 | `ZE_WORKER_DELIMITER` | Delimiter for hostname parsing | `-`     | `.` or `_`                                 |
+
+### OpenTelemetry Options
+
+| Key                                             | Description                                 | Default                            | Example                                 |
+| ----------------------------------------------- | ------------------------------------------- | ---------------------------------- | --------------------------------------- |
+| `ZE_WORKER_OTEL_ENABLED`                        | Enables OpenTelemetry export                | `false`                            | `true`                                  |
+| `ZE_WORKER_OTEL_SERVICE_NAME`                   | Service name resource attribute             | `ze-k8s-workers`                   | `ze-k8s-workers-prod`                   |
+| `ZE_WORKER_OTEL_DEPLOYMENT_ENVIRONMENT`         | Deployment environment resource attribute   | `NODE_ENV`, otherwise `production` | `production`                            |
+| `ZE_WORKER_OTEL_METRIC_EXPORT_INTERVAL_MS`      | OTLP metric export interval in milliseconds | `60000`                            | `30000`                                 |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT`         | Base OTLP HTTP endpoint for all signals     | _(unset)_                          | `http://otel-collector:4318`            |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | Signal-specific OTLP HTTP traces endpoint   | _(unset)_                          | `http://otel-collector:4318/v1/traces`  |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Signal-specific OTLP HTTP metrics endpoint  | _(unset)_                          | `http://otel-collector:4318/v1/metrics` |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`    | Signal-specific OTLP HTTP logs endpoint     | _(unset)_                          | `http://otel-collector:4318/v1/logs`    |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_HEADERS`          | Base OTLP HTTP headers for all signals      | _(unset)_                          | `Authorization=Bearer%20TOKEN`          |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_TRACES_HEADERS`   | Signal-specific OTLP HTTP traces headers    | _(unset)_                          | `x-api-key=trace-key`                   |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_METRICS_HEADERS`  | Signal-specific OTLP HTTP metrics headers   | _(unset)_                          | `x-api-key=metrics-key`                 |
+| `ZE_WORKER_OTEL_EXPORTER_OTLP_LOGS_HEADERS`     | Signal-specific OTLP HTTP logs headers      | _(unset)_                          | `x-api-key=logs-key`                    |
+
+The worker also honors standard `OTEL_EXPORTER_OTLP_*` environment variables, including `OTEL_EXPORTER_OTLP_HEADERS` and signal-specific header variables. Signal-specific endpoint and header variables take precedence over the base values. `OTEL_SDK_DISABLED=true` disables telemetry.
 
 ### S3 Options
 
@@ -187,14 +268,12 @@ Check worker logs on startup to verify replication:
 
 ```bash
 # Workers with REPLICAS_URLS set (replicate to other regions)
-[K8s Worker] Replica mode enabled
-[K8s Worker] Replica name: us-east-1
-[K8s Worker] Replicating to 1 replica(s): https://ze.eu.example.com
+{"level":"info","message":"Replica mode enabled","zephyr.replica":"us-east-1"}
+{"level":"info","message":"Replica fan-out configured","zephyr.replica.count":1,"zephyr.replica.urls":["https://ze.eu.example.com"]}
 
 # Workers without REPLICAS_URLS (receive-only, share storage with primary)
-[K8s Worker] Replica mode enabled
-[K8s Worker] Replica name: us-east-2
-[K8s Worker] No replica URLs configured (receive-only mode)
+{"level":"info","message":"Replica mode enabled","zephyr.replica":"us-east-2"}
+{"level":"info","message":"No replica URLs configured; receive-only mode enabled"}
 ```
 
 ### Same-Region Scaling
@@ -373,6 +452,19 @@ All workers have `ZE_WORKER_REPLICAS_URLS` pointing to other regions' load balan
 1. Check S3 bucket exists and credentials have read/write access
 2. Verify Redis connection (host, port, password, TLS settings)
 3. Review worker logs for specific error messages
+
+#### Telemetry is not reaching the collector
+
+1. Confirm the collector accepts OTLP HTTP, not only OTLP gRPC
+2. Verify the worker pod can resolve and connect to the collector service
+3. Use the collector base URL for `ZE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT`, for example `http://otel-collector:4318`
+4. Include the full `/v1/traces`, `/v1/metrics`, or `/v1/logs` path when using signal-specific endpoints
+5. Configure OTLP headers when the collector requires a bearer token, API key, or tenant header
+6. Confirm `OTEL_SDK_DISABLED` is not set to `true`
+
+#### Logs are too verbose
+
+Set `ZE_WORKER_LOG_LEVEL` to `warn` or `error`. You can keep OpenTelemetry enabled while reducing stdout and exported log volume.
 
 #### Assets not serving correctly
 


### PR DESCRIPTION
### What's added in this PR?

Documented Kubernetes worker observability in `docs/cloud/kubernetes.mdx`.

- Added OpenTelemetry configuration examples for traces, metrics, and logs.
- Documented standard `OTEL_*` environment variables for OTLP endpoints, headers, service name, resource attributes, and exporter selection.
- Documented base and signal-specific OTLP endpoints.
- Documented OTLP auth headers and the Kubernetes Secret boundary for token/API-key values.
- Added structured JSON log examples and troubleshooting notes.

### What's the issues or discussion related to this PR (optional) ?

This aligns the Kubernetes deployment guide with the worker observability implementation so operators can configure their own OTLP collector using standard OpenTelemetry environment variables.

### Feature related update for this PR (if applicable)?

Enterprise Kubernetes deployment observability.

### (Optional) What's left to be done for this PR?

None.

### Who do you wish to review this PR other than required reviewers?

<!-- @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [x] I have added/updated our feature to sync with this PR
- [x] I have added an explanation of my changes
- [x] I have/will run tests, or ask for help to add test

Validation:

- `pnpm exec prettier --check docs/cloud/kubernetes.mdx`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
- `autoreview --mode local` clean
