### PR TITLE
docs: add CI token migration guide

### DIFF
--- a/docs/features/automation.mdx
+++ b/docs/features/automation.mdx
@@ -1,19 +1,23 @@
 ---
 title: CI/CD Automation
-description: Configure CI/CD automation for Zephyr Cloud using API tokens with GitHub Actions and GitLab CI/CD pipelines
+description: Configure CI/CD automation for Zephyr Cloud using CI tokens with GitHub Actions and GitLab CI/CD pipelines
 head:
   - - meta
     - property: og:description
-      content: Configure CI/CD automation for Zephyr Cloud using API tokens with GitHub Actions and GitLab CI/CD pipelines
+      content: Configure CI/CD automation for Zephyr Cloud using CI tokens with GitHub Actions and GitLab CI/CD pipelines
 ---
 
 # CI/CD Automation
 
-Zephyr requires an authenticated user to publish updates. To configure your CI/CD pipeline to build and deploy with Zephyr, you'll need to add a token to your pipeline configuration.
+Zephyr requires authenticated CI/CD pipelines to publish updates. Use CI tokens for deployment authentication.
 
-## Creating an API Token
+:::warning Deployment authentication has changed
+Do not use personal tokens with `ZE_SECRET_TOKEN` for deployments. Existing pipelines that use personal tokens or server tokens should migrate to CI tokens.
+:::
 
-First, create a token on your [API token](https://app.zephyr-cloud.io/profile/settings/user-tokens) page. This token will be used to authenticate your CI/CD pipeline with Zephyr.
+## Creating a CI Token
+
+First, create a CI token from **Organization Settings** > **CI tokens**. This token will be used to authenticate your CI/CD pipeline with Zephyr.
 
 ## GitHub Actions
 
@@ -25,12 +29,12 @@ Add your Zephyr token as a repository secret:
 2. Go to **Settings** → **Secrets and variables** → **Actions**
 3. Click **New repository secret**
 4. Set:
-   - **Name**: `ZEPHYR_AUTH_TOKEN`
-   - **Secret**: Your Zephyr API token
+   - **Name**: `ZEPHYR_CI_TOKEN`
+   - **Secret**: Your Zephyr CI token
 
 ### Using in Workflow
 
-The secret must be assigned to the `ZE_SECRET_TOKEN` environment variable:
+The secret must be assigned to the `ZE_CI_TOKEN` environment variable:
 
 ```yml title=".github/workflows/deploy.yml"
 name: Deploy with Zephyr
@@ -44,7 +48,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      ZE_SECRET_TOKEN: ${{ secrets.ZEPHYR_AUTH_TOKEN }}
+      ZE_CI_TOKEN: ${{ secrets.ZEPHYR_CI_TOKEN }}
 
     steps:
       - uses: actions/checkout@v3
@@ -71,8 +75,8 @@ Add your Zephyr token as a CI/CD variable:
 3. Expand the **Variables** section
 4. Click **Add variable**
 5. Set:
-   - **Key**: `ZE_SECRET_TOKEN`
-   - **Value**: Your Zephyr API token
+   - **Key**: `ZE_CI_TOKEN`
+   - **Value**: Your Zephyr CI token
    - **Type**: Variable
    - **Environment scope**: All (or specify environments)
    - **Protect variable**: ✓ (recommended)
@@ -109,7 +113,7 @@ build:
   script:
     - npm run build
   variables:
-    ZE_SECRET_TOKEN: $ZE_SECRET_TOKEN
+    ZE_CI_TOKEN: $ZE_CI_TOKEN
   artifacts:
     paths:
       - dist/
@@ -124,26 +128,26 @@ deploy:
   environment:
     name: production
   variables:
-    ZE_SECRET_TOKEN: $ZE_SECRET_TOKEN
+    ZE_CI_TOKEN: $ZE_CI_TOKEN
 ```
 
 ## Plugin Behavior
 
-When the Zephyr plugin detects the `ZE_SECRET_TOKEN` environment variable, it will:
+When the Zephyr plugin detects the `ZE_CI_TOKEN` environment variable, it will:
 
 1. Use the token for automatic authentication
 2. Skip the interactive login step
 3. Display this message in the console:
 
 ```shell
- ZEPHYR   Token found in environment. Using secret token for authentication
+ ZEPHYR   Token found in environment. Using CI token for authentication
 ```
 
 ## Troubleshooting
 
 ### Token not found
 
-- Ensure the variable name is exactly `ZE_SECRET_TOKEN`
+- Ensure the variable name is exactly `ZE_CI_TOKEN`
 - Verify the variable is available in the job environment
 - Check that the token hasn't expired
 

--- a/docs/features/ci-cd-personal-token.mdx
+++ b/docs/features/ci-cd-personal-token.mdx
@@ -1,232 +1,37 @@
 ---
-title: CI/CD - Personal token
-description: Integrate Zephyr Cloud with your continuous integration and deployment pipelines
+title: Personal token deployments
+description: Personal tokens remain available, but they are no longer the supported authentication method for Zephyr deployments from CI/CD.
 head:
   - - meta
     - property: og:description
-      content: Integrate Zephyr Cloud with your continuous integration and deployment pipelines
+      content: Personal tokens remain available, but they are no longer the supported authentication method for Zephyr deployments from CI/CD.
 ---
 
-import { Steps } from '@rspress/core/theme';
+# Personal token deployments
 
-# CI/CD Integration using Personal token
+Personal tokens are no longer the supported way to authenticate Zephyr deployments from CI/CD pipelines.
 
-Integrate Zephyr Cloud into your continuous integration and deployment pipelines to automate your deployment workflow. This guide covers setup for GitHub Actions and GitLab CI/CD.
+Personal tokens still exist for user-scoped access where supported, but deployment authentication is moving to CI tokens. CI tokens are organization-scoped credentials designed for build pipelines and use the `ZE_CI_TOKEN` environment variable.
 
-:::info Alternative: Server Tokens
-Personal tokens authenticate as individual users. For organization-level authentication in CI/CD, consider using Server Tokens instead. Server tokens provide centralized management and don't require individual user credentials. See the [CI/CD Server Token guide](/features/ci-cd-server-token) for details.
+:::warning Deployment authentication is changing
+Do not add `ZE_SECRET_TOKEN` to new deployment pipelines. Existing deployment pipelines that use personal tokens should migrate to CI tokens.
 :::
 
-## Overview
+## What to use instead
 
-- [Generate API Token](#generate-an-api-token)
-- [GitHub Actions Setup](#github-actions)
-- [GitLab CI/CD Setup](#gitlab-cicd)
-- [Troubleshooting](#troubleshooting)
+Use CI tokens for deployments from GitHub Actions, GitLab CI/CD, and other build pipelines.
 
-## Generate an API Token
+Follow the [deployment auth migration guide](/migrations/ci-token-migration) to replace `ZE_SECRET_TOKEN` with `ZE_CI_TOKEN`.
 
-To use Zephyr Cloud in CI/CD pipelines, you'll need an API token for authentication:
+## What changes for personal tokens
 
-<Steps>
-### Click on your avatar
-In the upper right you should see your user's avatar with a dropdown menu
-
-### Select My Profile
-
-One of the options in this menu should be "My Profile"
-
-### Select the settings tab
-
-Once on the profile page, select the settings tab from the tab options
-
-### Select API Tokens from the left navigation
-
-On the left hand navigation there should be an option for "API Token" - select this option
-
-### Click Generate Token Button
-
-Fill out the required information about the token you're about to generate
-
-![token screen](../public/token-screen.webp)
-
-### Click Generate
-
-Copy the token for usage where you need to use it
-
-</Steps>
-
-## GitHub Actions
-
-Zephyr requires an authenticated user to publish updates. Configure your GitHub Actions pipeline to build and deploy with Zephyr by adding a token to your repository secrets.
-
-### Adding the GitHub Secret
-
-1. Create a token on your [API token](https://app.zephyr-cloud.io/profile/settings/user-tokens) page
-2. Add it as a repository secret in GitHub
-3. The secret must be assigned to the `ZE_SECRET_TOKEN` environment variable
-
-```yml title="pull_request.yml"
-env:
-  ZE_SECRET_TOKEN: ${{ secrets.ZEPHYR_AUTH_TOKEN }}
-```
-
-### Authentication Behavior
-
-When the Zephyr plugin detects the `ZE_SECRET_TOKEN` environment variable, it will automatically authenticate with the Zephyr API, bypassing the usual login step.
-
-You'll see this confirmation in the console:
-
-```shell
- ZEPHYR   Token found in environment. Using secret token for authentication
-```
-
-## GitLab CI/CD
-
-Configure your GitLab Runner pipeline to build and deploy with Zephyr by adding a token to the CI/CD variables.
-
-### Adding the GitLab CI/CD Variable
-
-1. Create a full access token on your [API token](https://app.zephyr-cloud.io/profile/settings/user-tokens) page
-2. Add it as a CI/CD variable in your GitLab project:
-
-**Steps to add the token:**
-
-1. Navigate to your GitLab project
-2. Go to **Settings** → **CI/CD**
-3. Expand the **Variables** section
-4. Click **Add variable**
-5. Configure the variable:
-   - **Key**: `ZE_SECRET_TOKEN`
-   - **Value**: Your Zephyr API token
-   - **Type**: Variable
-   - **Environment scope**: All (or specify specific environments)
-   - **Protect variable**: ✅ Check if you want to use it only in protected branches
-   - **Mask variable**: ✅ Check to hide the value in job logs
-
-### Using the Token in GitLab CI/CD
-
-In your `.gitlab-ci.yml` file, the token will be automatically available as an environment variable:
-
-```yml title=".gitlab-ci.yml"
-build:
-  stage: build
-  script:
-    - npm install
-    - npm run build
-  variables:
-    ZE_SECRET_TOKEN: $ZE_SECRET_TOKEN
-```
-
-For more explicit control, you can also reference it directly:
-
-```yml title=".gitlab-ci.yml"
-deploy:
-  stage: deploy
-  script:
-    - npm install
-    - npm run build
-  environment:
-    name: production
-  variables:
-    ZE_SECRET_TOKEN: $ZE_SECRET_TOKEN
-```
-
-### Authentication Behavior
-
-When the Zephyr plugin detects the `ZE_SECRET_TOKEN` environment variable, it will automatically authenticate with the Zephyr API, bypassing the usual login step.
-
-You'll see this confirmation in the console:
-
-```shell
- ZEPHYR   Token found in environment. Using secret token for authentication
-```
-
-### Complete Pipeline Example
-
-Here's a full GitLab CI/CD pipeline configured for Zephyr deployment:
-
-```yml title=".gitlab-ci.yml"
-stages:
-  - install
-  - build
-  - deploy
-
-variables:
-  npm_config_cache: '$CI_PROJECT_DIR/.npm'
-
-cache:
-  key: ${CI_COMMIT_REF_SLUG}
-  paths:
-    - .npm/
-    - node_modules/
-
-install:
-  stage: install
-  script:
-    - npm ci --cache .npm --prefer-offline
-  artifacts:
-    paths:
-      - node_modules/
-    expire_in: 1 hour
-
-build:
-  stage: build
-  script:
-    - npm run build
-  artifacts:
-    paths:
-      - dist/
-    expire_in: 1 day
-  variables:
-    ZE_SECRET_TOKEN: $ZE_SECRET_TOKEN
-
-deploy:
-  stage: deploy
-  script:
-    - npm run deploy
-  only:
-    - main
-  environment:
-    name: production
-  variables:
-    ZE_SECRET_TOKEN: $ZE_SECRET_TOKEN
-```
-
-## Troubleshooting
-
-### Authentication Issues
-
-**Token not found error:**
-
-- Verify the variable name is exactly `ZE_SECRET_TOKEN`
-- Ensure the variable is available in the environment where your job runs
-- Check that the token hasn't expired
-
-### GitLab-Specific Issues
-
-**Protected variables:**
-
-- If using protected variables, ensure your pipeline runs on a protected branch or tag
-
-**Masked variables:**
-
-- Masked variables won't appear in job logs (recommended for security)
-- Temporarily unmask if you need to troubleshoot, then re-mask for production
-
-**Variable scope:**
-
-- Check that the variable scope matches your pipeline's environment requirements
+- Personal tokens are not being removed.
+- Personal-token deployment authentication is going away.
+- Existing deployment jobs should stop using `ZE_SECRET_TOKEN`.
+- User-scoped token use outside deployments should continue only where the product supports it.
 
 ## Related Documentation
 
-**CI/CD & Deployment:**
-
-- **[Server Token CI/CD Integration](/features/ci-cd-server-token)** - Organization-level authentication for CI/CD
-- **[Automation](/features/automation)** - Automated workflows and deployment strategies
-- **[Tags & Environments](/features/tags-environments)** - Managing deployment targets
-
-**Getting Started:**
-
-- **[Quick Start](/getting-started/quick-start)** - Initial setup and first deployment
-- **[Integration Guides](/integrations/existing-app)** - Adding Zephyr to existing applications
+- [Migrate deployment auth to CI tokens](/migrations/ci-token-migration)
+- [CI/CD server token guide](/features/ci-cd-server-token)
+- [Automation](/features/automation)

--- a/docs/features/ci-cd-server-token.mdx
+++ b/docs/features/ci-cd-server-token.mdx
@@ -1,16 +1,22 @@
 ---
-title: CI/CD - Server token
+title: Server token deployments
 description: The Server Auth Token allows you to authenticate Zephyr plugins at the organization level without needing individual user credentials for every operation. It identifies the user performing actions via their email and enables secure access to Zephyr on behalf of your organization.
 ---
 
 import { Steps } from '@rspress/core/theme';
 
-# CI/CD Integration using Server token
+# Server token deployments
 
 The Server Auth Token allows you to authenticate Zephyr plugins at the organization level without needing individual user credentials for every operation. It identifies the user performing actions via their email and enables secure access to Zephyr on behalf of your organization.
 
+:::warning Server-token deployment auth is going away
+Do not add `ZE_SERVER_TOKEN` to new deployment pipelines. Existing deployment pipelines that use server tokens should migrate to CI tokens with `ZE_CI_TOKEN`.
+
+Follow the [deployment auth migration guide](/migrations/ci-token-migration).
+:::
+
 :::info Alternative: Personal Tokens
-Server tokens provide organization-level authentication. For individual user authentication, see the Personal Token CI/CD Integration guide. Personal tokens are useful for personal projects or when you need user-specific permissions. Learn more in the [CI/CD Personal Token guide](/features/ci-cd-personal-token).
+Personal tokens remain available for user-scoped access where supported, but personal-token deployment auth is also going away. For deployments, use CI tokens.
 :::
 
 ## Overview

--- a/docs/features/ci-token-migration.mdx
+++ b/docs/features/ci-token-migration.mdx
@@ -1,0 +1,76 @@
+---
+title: Migrate server tokens to CI tokens
+description: Replace ZE_SERVER_TOKEN and ZE_USER_EMAIL CI/CD authentication with organization-scoped CI tokens using ZE_CI_TOKEN.
+---
+
+# Migrate server tokens to CI tokens
+
+Server tokens are being replaced by CI tokens for CI/CD authentication. CI tokens are organization-scoped credentials made for build pipelines and use the `ZE_CI_TOKEN` environment variable.
+
+Use this guide when an existing pipeline authenticates Zephyr with `ZE_SERVER_TOKEN` and `ZE_USER_EMAIL`.
+
+## Before you start
+
+- You need access to the organization settings in Zephyr Cloud.
+- Keep the existing server token secret available until one CI-token build succeeds.
+- Update one repository or pipeline first, then repeat for the rest.
+
+## Create a CI token
+
+1. Open Zephyr Cloud.
+2. Go to **Organization Settings**.
+3. Open **CI tokens**.
+4. Generate a CI token.
+5. Copy the token value. It is only shown when the token is created.
+
+## Update GitHub Actions
+
+Add the CI token as a repository or organization secret, then expose it as `ZE_CI_TOKEN` in the job that runs the Zephyr build.
+
+```yml title=".github/workflows/build.yml"
+env:
+  ZE_CI_TOKEN: ${{ secrets.ZEPHYR_CI_TOKEN }}
+```
+
+Remove the old server-token variables from that job:
+
+```yml
+# Remove these after ZE_CI_TOKEN is working.
+ZE_SERVER_TOKEN: ${{ secrets.ZEPHYR_SERVER_TOKEN }}
+ZE_USER_EMAIL: user@example.com
+```
+
+## Update GitLab CI/CD
+
+Add the CI token as a masked CI/CD variable, then expose it as `ZE_CI_TOKEN`.
+
+```yml title=".gitlab-ci.yml"
+build:
+  stage: build
+  script:
+    - pnpm install --frozen-lockfile
+    - pnpm build
+  variables:
+    ZE_CI_TOKEN: $ZE_CI_TOKEN
+```
+
+Remove `ZE_SERVER_TOKEN` and `ZE_USER_EMAIL` after the CI-token pipeline succeeds.
+
+## Verify the migration
+
+Run the pipeline and confirm the Zephyr build authenticates without `ZE_SERVER_TOKEN`.
+
+If the build fails:
+
+- Confirm the secret name in the CI provider matches `ZE_CI_TOKEN`.
+- Confirm the CI token still exists in Zephyr Cloud.
+- Generate a new CI token if the original token value was lost.
+
+## Clean up server tokens
+
+After every pipeline for the repository uses `ZE_CI_TOKEN`, revoke the old server token from **Organization Settings** > **Server Tokens**.
+
+## Related docs
+
+- [CI/CD server token guide](/features/ci-cd-server-token)
+- [CI/CD personal token guide](/features/ci-cd-personal-token)

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -46,8 +46,8 @@ Deploy to Cloudflare, AWS, Fastly, or Vercel without changing a single line of c
 - **[Tags & Environments](/features/tags-environments)** - Detailed environment configuration and custom domains
 - **[Instant Rollbacks](/features/instant-rollbacks)** - Complex rollback scenarios and automated rollback triggers
 - **[Remote Dependencies](/features/remote-dependencies)** - Advanced dependency resolution and micro-frontend orchestration
-- **[CI/CD](/features/ci-cd-personal-token)** - Detailed integration guides for different CI/CD platforms with personal token
-- **[CI/CD](/features/ci-cd-server-token)** - Detailed integration guides for different CI/CD platforms with server token
+- **[CI/CD Automation](/features/automation)** - Configure deployments from build pipelines with CI tokens
+- **[Deployment auth migration](/migrations/ci-token-migration)** - Move server-token and personal-token deployments to CI tokens
 - **[Teams & Members](/features/teams-members)** - Team management, permissions, and collaboration features
 - **[Subscriptions](/features/subscriptions)** - Billing, usage monitoring, and plan management
 - **[Multi-Organization Subscriptions](/features/multi-organization-subscriptions)** - Link child organizations to an Enterprise subscription

--- a/docs/migrations/ci-token-migration.mdx
+++ b/docs/migrations/ci-token-migration.mdx
@@ -1,18 +1,23 @@
 ---
-title: Migrate server tokens to CI tokens
-description: Replace ZE_SERVER_TOKEN and ZE_USER_EMAIL CI/CD authentication with organization-scoped CI tokens using ZE_CI_TOKEN.
+title: Migrate deployment auth to CI tokens
+description: Replace ZE_SERVER_TOKEN, ZE_USER_EMAIL, and ZE_SECRET_TOKEN deployment authentication with organization-scoped CI tokens using ZE_CI_TOKEN.
 ---
 
-# Migrate server tokens to CI tokens
+# Migrate deployment auth to CI tokens
 
-Server tokens are being replaced by CI tokens for CI/CD authentication. CI tokens are organization-scoped credentials made for build pipelines and use the `ZE_CI_TOKEN` environment variable.
+CI tokens are becoming the supported way to authenticate deployments from build pipelines. CI tokens are organization-scoped credentials made for CI/CD and use the `ZE_CI_TOKEN` environment variable.
 
-Use this guide when an existing pipeline authenticates Zephyr with `ZE_SERVER_TOKEN` and `ZE_USER_EMAIL`.
+This migration affects both older deployment-auth paths:
+
+- Server tokens are going away.
+- Personal tokens remain available, but personal-token deployment auth is going away.
+
+Use this guide when an existing pipeline authenticates Zephyr with `ZE_SERVER_TOKEN` and `ZE_USER_EMAIL`, or with `ZE_SECRET_TOKEN`.
 
 ## Before you start
 
 - You need access to the organization settings in Zephyr Cloud.
-- Keep the existing server token secret available until one CI-token build succeeds.
+- Keep the existing deployment secret available until one CI-token build succeeds.
 - Update one repository or pipeline first, then repeat for the rest.
 
 ## Create a CI token
@@ -32,12 +37,13 @@ env:
   ZE_CI_TOKEN: ${{ secrets.ZEPHYR_CI_TOKEN }}
 ```
 
-Remove the old server-token variables from that job:
+Remove the old deployment-auth variables from that job:
 
 ```yml
 # Remove these after ZE_CI_TOKEN is working.
 ZE_SERVER_TOKEN: ${{ secrets.ZEPHYR_SERVER_TOKEN }}
 ZE_USER_EMAIL: user@example.com
+ZE_SECRET_TOKEN: ${{ secrets.ZEPHYR_PERSONAL_TOKEN }}
 ```
 
 ## Update GitLab CI/CD
@@ -54,11 +60,11 @@ build:
     ZE_CI_TOKEN: $ZE_CI_TOKEN
 ```
 
-Remove `ZE_SERVER_TOKEN` and `ZE_USER_EMAIL` after the CI-token pipeline succeeds.
+Remove `ZE_SERVER_TOKEN`, `ZE_USER_EMAIL`, and `ZE_SECRET_TOKEN` after the CI-token pipeline succeeds.
 
 ## Verify the migration
 
-Run the pipeline and confirm the Zephyr build authenticates without `ZE_SERVER_TOKEN`.
+Run the pipeline and confirm the Zephyr build authenticates without `ZE_SERVER_TOKEN` or `ZE_SECRET_TOKEN`.
 
 If the build fails:
 
@@ -66,9 +72,11 @@ If the build fails:
 - Confirm the CI token still exists in Zephyr Cloud.
 - Generate a new CI token if the original token value was lost.
 
-## Clean up server tokens
+## Clean up old deployment tokens
 
 After every pipeline for the repository uses `ZE_CI_TOKEN`, revoke the old server token from **Organization Settings** > **Server Tokens**.
+
+If a personal token was only used for deployments, revoke it from your profile settings. If the personal token is used for non-deployment workflows, keep it there and remove it only from CI/CD deployment jobs.
 
 ## Related docs
 

--- a/docs/tutorials/metro.mdx
+++ b/docs/tutorials/metro.mdx
@@ -627,5 +627,5 @@ Now that you have Module Federation working with Metro, explore these advanced t
 - Check out [Remote Dependencies](/features/remote-dependencies) for advanced dependency configuration
 - Review [End-to-End Testing](/tutorials/e2e-testing) for testing federated applications
 - Understand [Versioning and Tags](/features/versioning-tags) for managing deployments
-- Set up [CI/CD pipelines](/features/ci-cd-personal-token) for automated deployments with Personal token
-- Set up [CI/CD pipelines](/features/ci-cd-server-token) for automated deployments with Server token
+- Set up [CI/CD pipelines](/features/automation) for automated deployments with CI tokens
+- Migrate existing [personal-token or server-token deployments](/migrations/ci-token-migration) to CI tokens

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -115,6 +115,10 @@ const sidebar: Sidebar = {
           link: '/features/ci-cd-server-token',
         },
         {
+          text: 'Migrate server tokens to CI tokens',
+          link: '/features/ci-token-migration',
+        },
+        {
           text: 'Environment Overrides',
           link: '/features/environment-overrides',
         },

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -107,16 +107,12 @@ const sidebar: Sidebar = {
           link: '/features/file-logging',
         },
         {
-          text: 'CI/CD - Personal token',
+          text: 'Personal token deployments',
           link: '/features/ci-cd-personal-token',
         },
         {
-          text: 'CI/CD - Server token',
+          text: 'Server token deployments',
           link: '/features/ci-cd-server-token',
-        },
-        {
-          text: 'Migrate server tokens to CI tokens',
-          link: '/features/ci-token-migration',
         },
         {
           text: 'Environment Overrides',
@@ -133,6 +129,17 @@ const sidebar: Sidebar = {
         {
           text: 'Multi-Organization Subscriptions',
           link: '/features/multi-organization-subscriptions',
+        },
+      ],
+    },
+    {
+      text: 'Migrations',
+      collapsed: false,
+      collapsible: true,
+      items: [
+        {
+          text: 'Server tokens to CI tokens',
+          link: '/migrations/ci-token-migration',
         },
       ],
     },


### PR DESCRIPTION
### What's added in this PR?

Adds a dedicated **Migrations** docs section and moves the CI token migration guide to `/migrations/ci-token-migration`.

Also updates deployment-auth docs so the migration covers both deprecated paths:
- Server tokens are going away.
- Personal tokens remain, but personal-token deployment auth is going away.
- Deployment pipelines should use CI tokens via `ZE_CI_TOKEN`.

### What's the issues or discussion related to this PR (optional) ?

The app now warns users that deployment authentication is moving to CI tokens and links to this migration guide from Server Tokens UI surfaces.

### Feature related update for this PR (if applicable)?

N/A

### (Optional) What's left to be done for this PR?

N/A

### Who do you wish to review this PR other than required reviewers?

<!-- @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [x] I have added/updated our feature to sync with this PR
- [x] I have added an explanation of my changes
- [x] I have/will run tests, or ask for help to add test

Validation:
- `pnpm build` passed
- `git diff --check` passed

Preview: https://nestor-lopez-25754-zephyr-cloud-docs-zephyr-docum-c1fdc112e-ze.zephyr-cloud.io
