### PR TITLE
docs: document immutable dependency URLs

### DIFF
--- a/docs/features/remote-dependencies.mdx
+++ b/docs/features/remote-dependencies.mdx
@@ -24,6 +24,7 @@ Want to control which version of a remote your environment consumes without rebu
 - [Understanding Application UIDs](#understanding-application-uids)
 - [Configuration](#zephyr-dependencies-configuration)
 - [Version Selectors](#supported-declaration-formats)
+- [Immutable Version URLs](#pin-resolved-dependencies-to-version-urls)
 - [Build Context & Resolution](#build-context-and-dynamic-resolution)
 - [Best Practices](#best-practices)
 
@@ -278,6 +279,43 @@ Use the full UID format when:
 - The remote application is in a different repository
 - The remote application is in a different organization
 - You need to disambiguate between applications with the same name
+
+## Pin Resolved Dependencies to Version URLs
+
+By default, Zephyr keeps the URL identity of a tag or environment selector in the final
+Module Federation configuration. For example, `header@staging` resolves through the
+`staging` environment URL. If that environment later points to another version, an
+already-built host can load the newer version.
+
+To keep the deployment selected at build time, create an optional Zephyr project config
+and set `dependencyUrlMode` to `version`:
+
+```ts title="zephyr.config.ts"
+export default {
+  dependencyUrlMode: 'version',
+};
+```
+
+The config file does not exist until you add it. Zephyr searches upward from the
+bundler's project directory and supports `zephyr.config.ts`, `.mts`, `.cts`, `.js`,
+`.mjs`, and `.cjs`.
+
+The selector still decides which deployment Zephyr selects. Only the URL written into
+the build changes:
+
+| Mode                 | URL written into the host         | Effect when the selector moves                                  |
+| -------------------- | --------------------------------- | --------------------------------------------------------------- |
+| `selector` (default) | Tag or environment URL            | The existing host can load the newly selected version           |
+| `version`            | Immutable application-version URL | The existing host remains on the version selected at build time |
+
+`version` mode applies to tag, environment, semver, wildcard, and `workspace:*`
+resolution. Zephyr updates the deployment root, remote entry, and Module Federation
+manifest URLs together so runtimes that load either a manifest or a remote entry remain
+pinned to the same application version.
+
+:::tip Rebuild to update pinned dependencies
+After a tag or environment moves, rebuild the host to select and embed its new version.
+:::
 
 ## Build Context and Dynamic Resolution
 


### PR DESCRIPTION
### What's added in this PR?

Documents how to pin resolved `zephyr:dependencies` to immutable application-version URLs with `dependencyUrlMode: 'version'`.

- Adds the option to the existing Remote Dependencies guide and overview.
- Clarifies that `zephyr.config.*` is optional and user-created.
- Contrasts default mutable selector URLs with immutable version URLs.
- Explains supported selectors, affected Module Federation URL fields, and rebuild behavior.

### What's the issues or discussion related to this PR (optional) ?

Tag, environment, and workspace selectors select the correct deployment, but their URLs can move after the host is built. The paired implementation adds an opt-in mode that preserves selector-based selection while embedding the selected version's immutable URLs in the final Module Federation configuration.

### Feature related update for this PR (if applicable)?

- ZephyrCloudIO/zephyr-packages#502
- ZephyrCloudIO/zephyr-cloud-io#3571

### (Optional) What's left to be done for this PR?

None.

### Who do you wish to review this PR other than required reviewers?

No additional reviewers requested.

### (Required) Pre-PR/Merge checklist

- [x] I have added/updated our feature to sync with this PR
- [x] I have added an explanation of my changes
- [x] I have/will run tests, or ask for help to add test

Validation:

- `pnpm lint`
- `pnpm exec prettier --check docs/features/remote-dependencies.mdx`
- `git diff --check`
- Rspress rendered `doc_build/features/remote-dependencies.html` successfully
- `pnpm typecheck` reaches existing unrelated icon import and `rspress.config.ts` baseline errors
