### PR TITLE
docs(metro): make withZephyr optional

### DIFF
--- a/docs/bundlers/metro.mdx
+++ b/docs/bundlers/metro.mdx
@@ -206,6 +206,54 @@ const getConfig = async () => {
 module.exports = getConfig();
 ```
 
+### React Native CLI Configuration
+
+Create or modify the host application's `react-native.config.js` so host bundles are uploaded to Zephyr:
+
+```javascript
+// react-native.config.js
+const commands = require('@module-federation/metro-plugin-rnc-cli');
+const { updateManifest } = require('@module-federation/metro');
+const { zephyrCommandWrapper } = require('zephyr-metro-plugin');
+
+const wrappedFuncPromise = zephyrCommandWrapper(
+  commands.bundleMFHostCommand.func,
+  commands.loadMetroConfig,
+  () => {
+    updateManifest(
+      global.__METRO_FEDERATION_MANIFEST_PATH,
+      global.__METRO_FEDERATION_CONFIG,
+    );
+  },
+);
+
+const zephyrCommand = {
+  name: 'bundle-mf-host',
+  description: 'Bundles a Module Federation host with Zephyr Cloud',
+  func: async (...args) => {
+    const wrappedFunc = await wrappedFuncPromise;
+    return wrappedFunc(...args);
+  },
+  options: commands.bundleMFHostCommand.options,
+};
+
+module.exports = {
+  commands: [zephyrCommand],
+};
+```
+
+### Bundle Host Application
+
+Bundle your host application for the same platforms as its remotes:
+
+```bash
+# Bundle for iOS
+npx react-native bundle-mf-host --platform ios --dev false
+
+# Bundle for Android
+npx react-native bundle-mf-host --platform android --dev false
+```
+
 Use local HTTP manifest URLs during local development. Use Zephyr selectors such as `zephyr:miniApp@yourEnvironment` for builds that should resolve remotes from Zephyr Cloud.
 
 To enable OTA behavior, register the native cache before the host loads remote bundles:

--- a/docs/bundlers/metro.mdx
+++ b/docs/bundlers/metro.mdx
@@ -86,15 +86,19 @@ const mfConfig = {
   shareStrategy: 'version-first',
 };
 
-const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
+async function getConfig() {
+  const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
 
-module.exports = withModuleFederation(baseConfig, mfConfig, {
-  flags: {
-    unstable_patchHMRClient: true,
-    unstable_patchInitializeCore: true,
-    unstable_patchRuntimeRequire: true,
-  },
-});
+  return withModuleFederation(baseConfig, mfConfig, {
+    flags: {
+      unstable_patchHMRClient: true,
+      unstable_patchInitializeCore: true,
+      unstable_patchRuntimeRequire: true,
+    },
+  });
+}
+
+module.exports = getConfig();
 ```
 
 ### React Native CLI Configuration
@@ -187,15 +191,19 @@ const mfConfig = {
   runtimePlugins: [require.resolve('zephyr-native-cache/runtime-plugin')],
 };
 
-const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
+const getConfig = async () => {
+  const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
 
-module.exports = withModuleFederation(baseConfig, mfConfig, {
-  flags: {
-    unstable_patchHMRClient: true,
-    unstable_patchInitializeCore: true,
-    unstable_patchRuntimeRequire: true,
-  },
-});
+  return withModuleFederation(baseConfig, mfConfig, {
+    flags: {
+      unstable_patchHMRClient: true,
+      unstable_patchInitializeCore: true,
+      unstable_patchRuntimeRequire: true,
+    },
+  });
+};
+
+module.exports = getConfig();
 ```
 
 Use local HTTP manifest URLs during local development. Use Zephyr selectors such as `zephyr:miniApp@yourEnvironment` for builds that should resolve remotes from Zephyr Cloud.

--- a/docs/bundlers/metro.mdx
+++ b/docs/bundlers/metro.mdx
@@ -56,7 +56,6 @@ Mini applications expose modules to be consumed by host applications:
 // metro.config.js
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 const { withModuleFederation } = require('@module-federation/metro');
-const { withZephyr } = require('zephyr-metro-plugin');
 
 const config = {
   resolver: { useWatchman: false },
@@ -87,23 +86,15 @@ const mfConfig = {
   shareStrategy: 'version-first',
 };
 
-async function getConfig() {
-  const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
-  const zephyrConfig = await withZephyr({
-    name: mfConfig.name,
-    target: process.env.ZEPHYR_TARGET === 'android' ? 'android' : 'ios',
-  })(baseConfig);
+const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
 
-  return withModuleFederation(zephyrConfig, mfConfig, {
-    flags: {
-      unstable_patchHMRClient: true,
-      unstable_patchInitializeCore: true,
-      unstable_patchRuntimeRequire: true,
-    },
-  });
-}
-
-module.exports = getConfig();
+module.exports = withModuleFederation(baseConfig, mfConfig, {
+  flags: {
+    unstable_patchHMRClient: true,
+    unstable_patchInitializeCore: true,
+    unstable_patchRuntimeRequire: true,
+  },
+});
 ```
 
 ### React Native CLI Configuration
@@ -162,7 +153,6 @@ Host applications load and orchestrate mini-applications:
 ```javascript
 // metro.config.js
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
-const { withZephyr } = require('zephyr-metro-plugin');
 const { withModuleFederation } = require('@module-federation/metro');
 
 const miniAppPort = process.env.MINI_APP_PORT ?? '8082';
@@ -197,24 +187,15 @@ const mfConfig = {
   runtimePlugins: [require.resolve('zephyr-native-cache/runtime-plugin')],
 };
 
-const getConfig = async () => {
-  const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
-  const zephyrConfig = await withZephyr({
-    name: mfConfig.name,
-    remotes: mfConfig.remotes,
-    target: process.env.ZEPHYR_TARGET === 'android' ? 'android' : 'ios',
-  })(baseConfig);
+const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
 
-  return withModuleFederation(zephyrConfig, mfConfig, {
-    flags: {
-      unstable_patchHMRClient: true,
-      unstable_patchInitializeCore: true,
-      unstable_patchRuntimeRequire: true,
-    },
-  });
-};
-
-module.exports = getConfig();
+module.exports = withModuleFederation(baseConfig, mfConfig, {
+  flags: {
+    unstable_patchHMRClient: true,
+    unstable_patchInitializeCore: true,
+    unstable_patchRuntimeRequire: true,
+  },
+});
 ```
 
 Use local HTTP manifest URLs during local development. Use Zephyr selectors such as `zephyr:miniApp@yourEnvironment` for builds that should resolve remotes from Zephyr Cloud.

--- a/docs/features/react-native-ota-updates.mdx
+++ b/docs/features/react-native-ota-updates.mdx
@@ -100,11 +100,15 @@ const mfFlags = {
   },
 };
 
-const baseConfig = mergeConfig(getDefaultConfig(__dirname), {
-  resolver: { useWatchman: false },
-});
+async function getConfig() {
+  const baseConfig = mergeConfig(getDefaultConfig(__dirname), {
+    resolver: { useWatchman: false },
+  });
 
-module.exports = withModuleFederation(baseConfig, mfConfig, mfFlags);
+  return withModuleFederation(baseConfig, mfConfig, mfFlags);
+}
+
+module.exports = getConfig();
 ```
 
 Use local HTTP manifest URLs during local development. Use Zephyr selectors such as `zephyr:profile@production`, `zephyr:profile@staging`, or `zephyr:profile@latest` for builds that should resolve through Zephyr Cloud and receive OTA changes from the corresponding environment or tag.

--- a/docs/features/react-native-ota-updates.mdx
+++ b/docs/features/react-native-ota-updates.mdx
@@ -62,7 +62,6 @@ Add the native cache runtime plugin to the host's Module Federation config. The 
 ```js title="apps/host/metro.config.js"
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 const { withModuleFederation } = require('@module-federation/metro');
-const { withZephyr } = require('zephyr-metro-plugin');
 
 const useZephyrRemotes = process.env.ZEPHYR_REMOTE_RESOLUTION === '1';
 
@@ -101,21 +100,11 @@ const mfFlags = {
   },
 };
 
-async function getConfig() {
-  const baseConfig = mergeConfig(getDefaultConfig(__dirname), {
-    resolver: { useWatchman: false },
-  });
+const baseConfig = mergeConfig(getDefaultConfig(__dirname), {
+  resolver: { useWatchman: false },
+});
 
-  const zephyrConfig = await withZephyr({
-    name: mfConfig.name,
-    remotes: mfConfig.remotes,
-    target: process.env.ZEPHYR_TARGET === 'android' ? 'android' : 'ios',
-  })(baseConfig);
-
-  return withModuleFederation(zephyrConfig, mfConfig, mfFlags);
-}
-
-module.exports = getConfig();
+module.exports = withModuleFederation(baseConfig, mfConfig, mfFlags);
 ```
 
 Use local HTTP manifest URLs during local development. Use Zephyr selectors such as `zephyr:profile@production`, `zephyr:profile@staging`, or `zephyr:profile@latest` for builds that should resolve through Zephyr Cloud and receive OTA changes from the corresponding environment or tag.
@@ -190,7 +179,7 @@ rnef bundle-mf-remote --platform ios --dev false
 rnef bundle-mf-remote --platform android --dev false
 ```
 
-The host must resolve the same platform that the remote was published for. `withZephyr({ target: 'ios' })` resolves iOS remote artifacts, and `withZephyr({ target: 'android' })` resolves Android remote artifacts.
+The host must resolve the same platform that the remote was published for.
 
 ## Apply Updates In The App
 

--- a/docs/tutorials/metro.mdx
+++ b/docs/tutorials/metro.mdx
@@ -111,7 +111,6 @@ Create or modify your `metro.config.js` file in the mini application:
 // MiniApp/metro.config.js
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 const { withModuleFederation } = require('@module-federation/metro');
-const { withZephyr } = require('zephyr-metro-plugin');
 
 /**
  * Metro configuration
@@ -148,23 +147,15 @@ const mfConfig = {
   shareStrategy: 'version-first',
 };
 
-async function getConfig() {
-  const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
-  const zephyrConfig = await withZephyr({
-    name: mfConfig.name,
-    target: process.env.ZEPHYR_TARGET === 'android' ? 'android' : 'ios',
-  })(baseConfig);
+const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
 
-  return withModuleFederation(zephyrConfig, mfConfig, {
-    flags: {
-      unstable_patchHMRClient: true,
-      unstable_patchInitializeCore: true,
-      unstable_patchRuntimeRequire: true,
-    },
-  });
-}
-
-module.exports = getConfig();
+module.exports = withModuleFederation(baseConfig, mfConfig, {
+  flags: {
+    unstable_patchHMRClient: true,
+    unstable_patchInitializeCore: true,
+    unstable_patchRuntimeRequire: true,
+  },
+});
 ```
 
 :::details{title="Configuration Breakdown"}
@@ -301,7 +292,6 @@ Create or modify your `metro.config.js` file in the host application:
 // HostApp/metro.config.js
 const path = require('node:path');
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
-const { withZephyr } = require('zephyr-metro-plugin');
 const { withModuleFederation } = require('@module-federation/metro');
 
 /**
@@ -343,24 +333,15 @@ const mfConfig = {
   runtimePlugins: [path.resolve(__dirname, './runtime-plugin.ts')],
 };
 
-const getConfig = async () => {
-  const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
-  const zephyrConfig = await withZephyr({
-    name: mfConfig.name,
-    remotes: mfConfig.remotes,
-    target: process.env.ZEPHYR_TARGET === 'android' ? 'android' : 'ios',
-  })(baseConfig);
+const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
 
-  return withModuleFederation(zephyrConfig, mfConfig, {
-    flags: {
-      unstable_patchHMRClient: true,
-      unstable_patchInitializeCore: true,
-      unstable_patchRuntimeRequire: true,
-    },
-  });
-};
-
-module.exports = getConfig();
+module.exports = withModuleFederation(baseConfig, mfConfig, {
+  flags: {
+    unstable_patchHMRClient: true,
+    unstable_patchInitializeCore: true,
+    unstable_patchRuntimeRequire: true,
+  },
+});
 ```
 
 :::details{title="Configuration Breakdown"}

--- a/docs/tutorials/metro.mdx
+++ b/docs/tutorials/metro.mdx
@@ -365,7 +365,54 @@ module.exports = getConfig();
 
 :::
 
-### Step 2: Configure Zephyr Dependencies
+### Step 2: Configure React Native CLI
+
+Create or modify the host application's `react-native.config.js` so host bundles are uploaded to Zephyr Cloud:
+
+```javascript
+// HostApp/react-native.config.js
+const commands = require('@module-federation/metro-plugin-rnc-cli');
+const { updateManifest } = require('@module-federation/metro');
+const { zephyrCommandWrapper } = require('zephyr-metro-plugin');
+
+const wrappedFuncPromise = zephyrCommandWrapper(
+  commands.bundleMFHostCommand.func,
+  commands.loadMetroConfig,
+  () => {
+    updateManifest(
+      global.__METRO_FEDERATION_MANIFEST_PATH,
+      global.__METRO_FEDERATION_CONFIG,
+    );
+  },
+);
+
+const zephyrCommand = {
+  name: 'bundle-mf-host',
+  description: 'Bundles a Module Federation host with Zephyr Cloud',
+  func: async (...args) => {
+    const wrappedFunc = await wrappedFuncPromise;
+    return wrappedFunc(...args);
+  },
+  options: commands.bundleMFHostCommand.options,
+};
+
+module.exports = {
+  commands: [zephyrCommand],
+};
+```
+
+:::details{title="Why This Configuration?"}
+
+This configuration adds a custom React Native CLI command that:
+
+- Resolves the host's Zephyr remote dependencies
+- Updates the Module Federation manifest
+- Bundles the host application
+- Uploads the host artifacts to Zephyr's edge network
+
+:::
+
+### Step 3: Configure Zephyr Dependencies
 
 To enable Zephyr Cloud integration, add the `zephyr:dependencies` field to your `package.json`:
 
@@ -394,7 +441,7 @@ For more information about managing dependencies, see [Remote Dependencies](/fea
 
 :::
 
-### Step 3: Load Mini Application in Your Code
+### Step 4: Load Mini Application in Your Code
 
 Now you can use the mini application in your host app:
 

--- a/docs/tutorials/metro.mdx
+++ b/docs/tutorials/metro.mdx
@@ -147,15 +147,19 @@ const mfConfig = {
   shareStrategy: 'version-first',
 };
 
-const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
+async function getConfig() {
+  const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
 
-module.exports = withModuleFederation(baseConfig, mfConfig, {
-  flags: {
-    unstable_patchHMRClient: true,
-    unstable_patchInitializeCore: true,
-    unstable_patchRuntimeRequire: true,
-  },
-});
+  return withModuleFederation(baseConfig, mfConfig, {
+    flags: {
+      unstable_patchHMRClient: true,
+      unstable_patchInitializeCore: true,
+      unstable_patchRuntimeRequire: true,
+    },
+  });
+}
+
+module.exports = getConfig();
 ```
 
 :::details{title="Configuration Breakdown"}
@@ -333,15 +337,19 @@ const mfConfig = {
   runtimePlugins: [path.resolve(__dirname, './runtime-plugin.ts')],
 };
 
-const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
+const getConfig = async () => {
+  const baseConfig = mergeConfig(getDefaultConfig(__dirname), config);
 
-module.exports = withModuleFederation(baseConfig, mfConfig, {
-  flags: {
-    unstable_patchHMRClient: true,
-    unstable_patchInitializeCore: true,
-    unstable_patchRuntimeRequire: true,
-  },
-});
+  return withModuleFederation(baseConfig, mfConfig, {
+    flags: {
+      unstable_patchHMRClient: true,
+      unstable_patchInitializeCore: true,
+      unstable_patchRuntimeRequire: true,
+    },
+  });
+};
+
+module.exports = getConfig();
 ```
 
 :::details{title="Configuration Breakdown"}


### PR DESCRIPTION
### What's added in this PR?

This draft proposes updating the React Native Module Federation documentation to:

- Remove `withZephyr` from the baseline Host and Remote Metro configurations.
- Use `withModuleFederation` with `zephyrCommandWrapper` as the documented deployment flow.
- Add the missing Host React Native CLI configuration and bundle commands.

### What's the issues or discussion related to this PR (optional) ?

The current documentation presents `withZephyr` as required. However, in the tested React Native flow, remote resolution, manifest updates, bundling, and uploads worked through `zephyrCommandWrapper` without it.

I could not identify a supported scenario that specifically requires `withZephyr`.

Related investigation: https://github.com/ZephyrCloudIO/zephyr-packages/issues/512#issuecomment-5132937206

### Feature related update for this PR (if applicable)?

Documentation-only proposal. No runtime behavior changes.

### (Optional) What's left to be done for this PR?

Before finalizing this change, could you confirm:

1. Is it safe to remove `withZephyr` from the baseline React Native setup?
2. Is there a supported scenario or runtime that still requires it?
3. If so, should it be documented as optional or scenario-specific instead?

### Who do you wish to review this PR other than required reviewers?

<!-- @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [x] I have added/updated our feature to sync with this PR
- [x] I have added an explanation of my changes
- [x] I have/will run tests, or ask for help to add test
