### PR TITLE
docs(metro): replace RNEF with Rock

### DIFF
--- a/docs/bundlers/metro.mdx
+++ b/docs/bundlers/metro.mdx
@@ -36,9 +36,9 @@ If you use React Native CLI custom commands, install the React Native CLI comman
 
 <PackageManagerTabs command="add --dev @module-federation/metro-plugin-rnc-cli" />
 
-If you use RNEF, install the RNEF Module Federation plugin:
+If you use Rock, install the Rock Module Federation plugin:
 
-<PackageManagerTabs command="add --dev @module-federation/metro-plugin-rnef" />
+<PackageManagerTabs command="add --dev @module-federation/metro-plugin-rock" />
 
 To enable React Native OTA updates in a host app, also install the native cache runtime:
 

--- a/docs/features/react-native-ota-updates.mdx
+++ b/docs/features/react-native-ota-updates.mdx
@@ -162,7 +162,7 @@ Production builds enable the cache automatically. Development builds keep the ca
 
 ## Configure Remote Builds
 
-Use the Zephyr Rock plugin in place of the stock `@module-federation/metro-plugin-rock` config plugin so `rock bundle-mf-remote` and `rock bundle-mf-host` upload Metro artifacts to Zephyr after the Module Federation build completes. Do not register both plugins because they provide the same command names.
+Use the Zephyr Rock plugin so `rock bundle-mf-remote` and `rock bundle-mf-host` upload Metro artifacts to Zephyr after the Module Federation build completes.
 
 ```js title="apps/remote/rock.config.mjs"
 import { platformAndroid } from '@rock-js/platform-android';

--- a/docs/features/react-native-ota-updates.mdx
+++ b/docs/features/react-native-ota-updates.mdx
@@ -42,7 +42,7 @@ Rollbacks use the same mechanism. If you roll back a Zephyr environment or move 
 
 Install the Metro and Module Federation packages in every host and remote app:
 
-<PackageManagerTabs command="add --dev zephyr-metro-plugin @module-federation/metro @module-federation/runtime @module-federation/metro-plugin-rnef" />
+<PackageManagerTabs command="add --dev zephyr-metro-plugin @module-federation/metro @module-federation/runtime @module-federation/metro-plugin-rock" />
 
 Install the native cache package in the host app:
 
@@ -162,13 +162,13 @@ Production builds enable the cache automatically. Development builds keep the ca
 
 ## Configure Remote Builds
 
-Use the Zephyr RNEF plugin so `rnef bundle-mf-remote` and `rnef bundle-mf-host` upload Metro artifacts to Zephyr after the Module Federation build completes.
+Use the Zephyr Rock plugin in place of the stock `@module-federation/metro-plugin-rock` config plugin so `rock bundle-mf-remote` and `rock bundle-mf-host` upload Metro artifacts to Zephyr after the Module Federation build completes. Do not register both plugins because they provide the same command names.
 
-```js title="apps/remote/rnef.config.mjs"
-import { platformAndroid } from '@rnef/platform-android';
-import { platformIOS } from '@rnef/platform-ios';
-import { pluginMetro } from '@rnef/plugin-metro';
-import { zephyrMetroRNEFPlugin } from 'zephyr-metro-plugin';
+```js title="apps/remote/rock.config.mjs"
+import { platformAndroid } from '@rock-js/platform-android';
+import { platformIOS } from '@rock-js/platform-ios';
+import { pluginMetro } from '@rock-js/plugin-metro';
+import { zephyrMetroRockPlugin } from 'zephyr-metro-plugin';
 
 export default {
   bundler: pluginMetro(),
@@ -176,7 +176,7 @@ export default {
     ios: platformIOS(),
     android: platformAndroid(),
   },
-  plugins: [zephyrMetroRNEFPlugin()],
+  plugins: [zephyrMetroRockPlugin()],
 };
 ```
 
@@ -184,10 +184,10 @@ Then publish a remote for each platform you support:
 
 ```bash
 # iOS remote build and upload
-rnef bundle-mf-remote --platform ios --dev false
+rock bundle-mf-remote --platform ios --dev false
 
 # Android remote build and upload
-rnef bundle-mf-remote --platform android --dev false
+rock bundle-mf-remote --platform android --dev false
 ```
 
 The host must resolve the same platform that the remote was published for. `withZephyr({ target: 'ios' })` resolves iOS remote artifacts, and `withZephyr({ target: 'android' })` resolves Android remote artifacts.
@@ -276,6 +276,5 @@ Use [`zephyr-native-cache-test`](https://github.com/ZephyrCloudIO/zephyr-native-
 
 - [`apps/host/index.js`](https://github.com/ZephyrCloudIO/zephyr-native-cache-test/blob/main/apps/host/index.js) for cache registration.
 - [`apps/host/metro.config.js`](https://github.com/ZephyrCloudIO/zephyr-native-cache-test/blob/main/apps/host/metro.config.js) for host runtime plugin wiring.
-- [`apps/host/rnef.config.mjs`](https://github.com/ZephyrCloudIO/zephyr-native-cache-test/blob/main/apps/host/rnef.config.mjs) for RNEF command integration.
 - [`apps/host/src/components/DevToolsPanel.tsx`](https://github.com/ZephyrCloudIO/zephyr-native-cache-test/blob/main/apps/host/src/components/DevToolsPanel.tsx) for polling status and manual controls.
 - [`ZEPHYR_OTA_DEMO.md`](https://github.com/ZephyrCloudIO/zephyr-native-cache-test/blob/main/ZEPHYR_OTA_DEMO.md) for the Zephyr-backed OTA dashboard walkthrough.


### PR DESCRIPTION
### What's added in this PR?

- Replace the remaining RNEF installation, configuration, and CLI references with their Rock equivalents.
- Use `@module-federation/metro-plugin-rock`, `rock.config.mjs`, `@rock-js/*`, `zephyrMetroRockPlugin`, and `rock bundle-*` in the Metro and React Native OTA guides.
- Remove the direct RNEF config link from the native cache example section until that example repository is migrated to Rock.

### What's the issues or discussion related to this PR (optional) ?

RNEF was rebranded to Rock, but the documentation still directed users to the deprecated RNEF package, configuration file, imports, and commands. This updates the documentation alongside [ZephyrCloudIO/zephyr-packages#532](https://github.com/ZephyrCloudIO/zephyr-packages/pull/532), which adds `zephyrMetroRockPlugin` while retaining the RNEF plugin for compatibility.

### Feature related update for this PR (if applicable)?

- Package implementation: https://github.com/ZephyrCloudIO/zephyr-packages/pull/532
- Documentation preview: https://sungyu-kang-229-zephyr-cloud-docs-zephyr-document-91402ee5f-ze.zephyrcloud.app

### (Optional) What's left to be done for this PR?

Migrate `ZephyrCloudIO/zephyr-native-cache-test` to Rock separately before restoring a direct config-file link from the example section.

### Who do you wish to review this PR other than required reviewers?

<!-- @zmzlois @arthurfiorette @zackarychapple -->

### (Required) Pre-PR/Merge checklist

- [x] I have added/updated our feature to sync with this PR
- [x] I have added an explanation of my changes
- [x] I have/will run tests, or ask for help to add test
