### PR TITLE
docs(errors): distinguish deployment recovery guidance

### DIFF
--- a/docs/errors/ze10016.mdx
+++ b/docs/errors/ze10016.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'ZE10016: Missing git configuration'
-description: 'ZE10016: Missing git configuration including remote origin URL, username, or email'
+title: 'ZE10016: Missing Git information'
+description: 'ZE10016: Stable Git branch, commit, identity, or remote information is unavailable'
 head:
   - - meta
     - property: og:description
-      content: 'ZE10016: Missing git configuration including remote origin URL, username, or email'
+      content: 'ZE10016: Stable Git branch, commit, identity, or remote information is unavailable'
 ---
 
 import { getErrorMessage } from '../../lib/error-helpers.ts';
@@ -19,16 +19,23 @@ The fastest way to resolve this error is to [join our Discord](https://discord.g
 
 <ErrorInfo code="ZE10016" terminal related="ZE10014,ZE10015,ZE10017" />
 
-There could be several reason why this error shows up - it could be because remote origin wasn't configured for the project directory; it could be because you haven't set a username for git; or it could be because you don't have an email set to your git config.
+Zephyr could not determine the stable repository information required for this deployment. Depending on the build, this can include the Git branch, commit, author identity, or `origin` remote.
 
-All of these information will affect your build and deployment through Zephyr as we use them to both authenticate you and deploy your application.
+Authentication failures use <ErrorLink code="ZE10018" /> instead. Logging in again does not create missing Git history or repository metadata.
 
 ## Debugging the error
 
-To make sure you have all the configuration set up correctly, you can do so by running this in your project directory (use arrow key to scroll down and check your remote origin's url)
+Run these commands in the project directory to identify the missing information:
 
-git config --list
+```bash
+git rev-parse --is-inside-work-tree
+git rev-parse HEAD
+git branch --show-current
+git remote -v
+git config user.name
+git config user.email
+```
 
-If you are missing username and email, please refer to <ErrorLink code="ZE10015" /> to configure it correctly.
+CI deployments require a checked-out commit and stable branch metadata. Ensure the checkout step includes the commit history and the CI provider exposes its branch or pull-request variables.
 
-If you are missing `remote origin url`, refer to <ErrorLink code="ZE10014" />.
+If the username or email is missing, see <ErrorLink code="ZE10015" />. If `origin` is missing, see <ErrorLink code="ZE10014" />.

--- a/docs/errors/ze10018.mdx
+++ b/docs/errors/ze10018.mdx
@@ -1,14 +1,15 @@
 ---
 title: 'ZE10018: Authentication error'
-description: 'ZE10018: Authentication error due to expired JWT token or missing account access'
+description: 'ZE10018: Zephyr authentication is missing, invalid, or expired'
 head:
   - - meta
     - property: og:description
-      content: 'ZE10018: Authentication error due to expired JWT token or missing account access'
+      content: 'ZE10018: Zephyr authentication is missing, invalid, or expired'
 ---
 
 import { getErrorMessage } from '../../lib/error-helpers.ts';
 import { ErrorInfo } from '../../components/errors/info.tsx';
+import { ErrorLink } from '../../components/errors/link.tsx';
 import { Steps } from '@rspress/core/theme';
 
 # {getErrorMessage('ZE10018')}
@@ -19,27 +20,24 @@ The fastest way to resolve this error is to [join our Discord](https://discord.g
 
 <ErrorInfo code="ZE10018" terminal />
 
-This error might happen for several reasons when you are running a build.
-While you are running a build, we are creating a snapshot of your application, transmitting your application details to the edge and most importantly, confirm with server your identity - whether you have enabled cloud integration, or using our managed cloud.
+Zephyr could not authenticate the account used by the deployment. The credential may be missing, invalid, or expired.
 
-If your local jwt token expired, or we couldn't locate your account (say you have deleted your account on your dashboard), or you don't access to an organization which manages the project you are trying to deploy to, or you they are all plausible reasons you are facing auth error.
+If authentication succeeds but the account cannot access the target, Zephyr reports <ErrorLink code="ZE10022" /> instead.
 
 ## Debugging the error
 
 <Steps>
 
-### Remove local zephyr config
+### Interactive builds
 
-If the reason is local JWT token expired, you can run below commands to remove your local configuration file:
+Run the deployment again from an interactive terminal. Zephyr opens the normal browser login flow and retries the operation once.
 
-rm -rf ~/.zephyr
+### Non-interactive builds
 
-Try to run a build again - the browser will prompt you to log in to assign you new JWT token and your deployment will be successful.
+CI and other non-interactive environments cannot open browser login. Provide the supported Zephyr token for that environment and verify that it has not expired.
 
-### No account or no access
+### Keep credentials private
 
-This most likely happen when you **clone** a repository belong to an organization (note that organizations in zephyr is linked to Github's organization) and you are not a maintainer or have access level higher than **viewer** in that organization.
-
-If that's the case, **fork** the repository instead should fix the issue.
+Do not print, export, share, or manually delete files from `~/.zephyr`. The agent invalidates only the credential rejected by the service.
 
 </Steps>

--- a/docs/errors/ze10019.mdx
+++ b/docs/errors/ze10019.mdx
@@ -1,10 +1,10 @@
 ---
 title: 'ZE10019: Failed to obtain build ID'
-description: 'ZE10019: Failed to obtain build ID due to missing configuration or insufficient write access'
+description: 'ZE10019: Build ID creation failed; inspect the reported reason for recovery'
 head:
   - - meta
     - property: og:description
-      content: 'ZE10019: Failed to obtain build ID due to missing configuration or insufficient write access'
+      content: 'ZE10019: Build ID creation failed; inspect the reported reason for recovery'
 ---
 
 import { getErrorMessage } from '../../lib/error-helpers.ts';
@@ -20,30 +20,28 @@ The fastest way to resolve this error is to [join our Discord](https://discord.g
 
 <ErrorInfo code="ZE10019" terminal />
 
-::: info
-This is one of the most common errors during build.
-:::
-
-Once we find your `application_uid` (composed by your github organization's name, project name and the `name` field in package.json, refer to <ErrorLink code="ZE10017" />), we will be collecting data from your local cache, verifying your JWT token and checking your write access to the related project. If we fail to find all the necessary configuration, we won't be able to obtain appropriate build id for you to continue with the deployment.
+Zephyr identified the application but could not create a Build ID. The diagnostic includes `Operation: create-build-id` and a `Reason` code that identifies the immediate blocker.
 
 ## Debugging the error
 
 <Steps>
 
-### Check your write access
+### Authentication reason
 
-You current logged in account on Zephyr dashboard might not have write access to this application
+For <ErrorLink code="ZE10018" />, complete normal browser login in an interactive terminal or provide a valid token in a non-interactive environment.
 
-You can log out either from our [Chrome Extension](https://chromewebstore.google.com/detail/zephyr-mission-control/liflhldchhinbaeplljlplhnbkdidedn) or from [dashboard](https://app.zephyr-cloud.io) and log in again with the correct account having write access.
+### Target access reason
 
-### Clear cache
+For <ErrorLink code="ZE10022" />, verify the application target and account permissions or ask an organization administrator for access. Reconfiguring Git or logging in with the same account will not grant access.
 
-Git configuration details for the project is different from previous build
+### Service availability reason
 
-One of the plausible way to debug this error is to remove your local zephyr configuration by running:
+For `ZE40035`, retry after confirming Zephyr service availability. If the problem persists, include the operation and reason codes when contacting support.
 
-rm -rf ~/.zephyr
+### Unexpected response
 
-And then try to run a build again.
+If no more specific reason is shown, confirm the `application_uid` is correct. See <ErrorLink code="ZE10017" /> for how Zephyr derives it.
+
+Do not print, export, share, or manually delete files from `~/.zephyr` while troubleshooting.
 
 </Steps>

--- a/docs/errors/ze10022.mdx
+++ b/docs/errors/ze10022.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'ZE10022: Auth forbidden error'
-description: 'ZE10022: Authentication forbidden - access denied to requested resource'
+title: 'ZE10022: Target access forbidden'
+description: 'ZE10022: The authenticated account cannot access the requested target'
 head:
   - - meta
     - property: og:description
-      content: 'ZE10022: Authentication forbidden - access denied to requested resource'
+      content: 'ZE10022: The authenticated account cannot access the requested target'
 ---
 
 import { getErrorMessage } from '../../lib/error-helpers.ts';
@@ -19,7 +19,7 @@ The fastest way to resolve this error is to [join our Discord](https://discord.g
 
 <ErrorInfo code="ZE10022" terminal />
 
-This error occurs when your authentication credentials are valid but you don't have permission to access the requested resource or perform the requested action.
+Authentication succeeded, but the account does not have permission to access the requested application, project, or organization. This is distinct from missing or expired authentication, which reports `ZE10018`.
 
 ## Debugging the error
 
@@ -29,16 +29,14 @@ This error occurs when your authentication credentials are valid but you don't h
 
 Ensure your account has the necessary permissions for the project or organization you're trying to access.
 
+### Verify the target
+
+Confirm that the configured organization, project, and application identify the target you intended to deploy.
+
 ### Check organization membership
 
-If working with an organization project, confirm you're a member of that organization with appropriate access rights.
+Confirm that the authenticated account belongs to the organization with the required role. Ask an organization administrator to grant access if necessary.
 
-### Re-authenticate
-
-Try clearing your local Zephyr credentials and logging in again from the [dashboard](https://app.zephyr-cloud.io) or [Chrome extension](https://chromewebstore.google.com/detail/zephyr-mission-control/liflhldchhinbaeplljlplhnbkdidedn):
-
-```bash
-rm -rf ~/.zephyr
-```
+Re-running Git setup or logging in again with the same account will not change target authorization. Do not print, export, share, or manually delete files from `~/.zephyr`.
 
 </Steps>


### PR DESCRIPTION
## Summary

- distinguish Git metadata, authentication, target access, and Build-ID recovery guidance
- map ZE10019 recovery to its reported reason code
- remove instructions to delete or expose files from `~/.zephyr`
- add CI-specific Git metadata checks for ZE10016

## Related work

- ZephyrCloudIO/zephyr-packages#604
- ZephyrCloudIO/zephyr-packages#609
- ZephyrCloudIO/zephyr-mono#577

## Verification

- `pnpm build`
- `pnpm lint`
- `pnpm exec prettier --check docs/errors/ze10016.mdx docs/errors/ze10018.mdx docs/errors/ze10019.mdx docs/errors/ze10022.mdx`
- `git diff --check`

Repository-wide `pnpm typecheck` still reports pre-existing unused React imports and the existing Rspress `EditLink.text` configuration mismatch.

Preview: https://rodrigo-1423-zephyr-cloud-docs-zephyr-documentati-bef8ad361-ze.zephyr-cloud.io